### PR TITLE
docs: libro técnico — 7 capítulos de investigación abierta

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@
 </p>
 
 <p align="center">
-  <strong>Automatizacion iOS desde macOS. Sin XCUITest. Sin servidor. Sin dependencias.</strong>
+  <strong>Automatización iOS desde macOS. Sin XCUITest. Sin servidor. Sin dependencias.</strong>
 </p>
 
 <p align="center">
   <a href="docs/libro/README.md">Leer el libro</a> •
-  <a href="#inicio-rapido">Inicio rapido</a> •
+  <a href="#inicio-rápido">Inicio rápido</a> •
   <a href="docs/libro/06-alternativas.md">Alternativas</a> •
   <a href="ROADMAP.md">Roadmap</a>
 </p>
 
 ---
 
-## Por que existe
+## Por qué existe
 
-Todas las herramientas de automatizacion iOS — Appium, Maestro, Detox — dependen de XCUITest por debajo. XCUITest requiere compilar un test target dentro de Xcode. Para hacer tap en un boton desde la terminal, necesitas un proyecto, un scheme, un build y un runner.
+Todas las herramientas de automatización iOS — Appium, Maestro, Detox — dependen de XCUITest por debajo. XCUITest requiere compilar un test target dentro de Xcode. Para hacer tap en un botón desde la terminal, necesitas un proyecto, un scheme, un build y un runner.
 
-Descubrimos que el Simulador iOS es una app de macOS que expone la UI de las apps iOS como elementos nativos de accesibilidad. Un `UIButton` con label "Login" aparece como `AXButton` con `kAXTitleAttribute = "Login"` en el arbol AX del Simulador.
+Descubrimos que el Simulador iOS es una app de macOS que expone la UI de las apps iOS como elementos nativos de accesibilidad. Un `UIButton` con label "Login" aparece como `AXButton` con `kAXTitleAttribute = "Login"` en el árbol AX del Simulador.
 
 No necesitas XCUITest. Solo un binario Swift de 311KB que hable con las APIs de accesibilidad de macOS.
 
@@ -30,35 +30,35 @@ auto type "Usuario" "correo@test.com"
 auto screenshot resultado.png
 ```
 
-## Que descubrimos
+## Qué descubrimos
 
-Tres hallazgos que no estan documentados en ningun otro lugar:
+Tres hallazgos que no estan documentados en ningún otro lugar:
 
-**1. La camara virtual requirio 10 intentos.** CMIOExtension (bloqueado por Apple), webcam mapping (no existe), dylib injection (PAC bloquea objetos), Swift ABI (closures no son function pointers)... hasta que `#undef AV_INIT_UNAVAILABLE` nos dejo crear instancias reales de `AVCapturePhoto`. → [Capitulo 3](docs/libro/03-la-camara-virtual.md)
+**1. La cámara virtual requirió 10 intentos.** CMIOExtension (bloqueado por Apple), webcam mapping (no existe), dylib injection (PAC bloquea objetos), Swift ABI (closures no son function pointers)... hasta que `#undef AV_INIT_UNAVAILABLE` nos dejó crear instancias reales de `AVCapturePhoto`. → [Capítulo 3](docs/libro/03-la-camara-virtual.md)
 
-**2. DYLD_INSERT_LIBRARIES como herramienta de testing.** Ninguna herramienta del mercado usa inyeccion de dylibs para mockear la camara en el Simulador iOS. Compilamos el mock como dylib, lo inyectamos al lanzar, y la imagen se puede cambiar en caliente sin relanzar la app. → [Capitulo 4](docs/libro/04-inyeccion-sin-recompilar.md)
+**2. DYLD_INSERT_LIBRARIES como herramienta de testing.** Ninguna herramienta del mercado usa inyección de dylibs para mockear la cámara en el Simulador iOS. Compilamos el mock como dylib, lo inyectamos al lanzar, y la imagen se puede cambiar en caliente sin relanzar la app. → [Capítulo 4](docs/libro/04-inyeccion-sin-recompilar.md)
 
-**3. Las restricciones de compilador no son restricciones de runtime.** `AV_INIT_UNAVAILABLE` es un macro que desaparece despues de compilar. `objc_setAssociatedObject` permite guardar datos en cualquier objeto sin conocer su layout interno. La barrera ObjC/Swift es mas profunda de lo que parece. → [Capitulo 3](docs/libro/03-la-camara-virtual.md)
+**3. Las restricciones de compilador no son restricciones de runtime.** `AV_INIT_UNAVAILABLE` es un macro que desaparece después de compilar. `objc_setAssociatedObject` permite guardar datos en cualquier objeto sin conocer su layout interno. La barrera ObjC/Swift es más profunda de lo que parece. → [Capítulo 3](docs/libro/03-la-camara-virtual.md)
 
 ## El libro
 
 Documentamos todo el proceso — los errores, los callejones sin salida, las decisiones y sus razones. No para vender AutoPilot, para que cualquier ingeniero que enfrente problemas similares tenga un punto de partida.
 
-| Capitulo | Que encontraras |
+| Capítulo | Qué encontrarás |
 |---|---|
-| [01 — El problema](docs/libro/01-el-problema.md) | Por que la automatizacion iOS esta rota |
+| [01 — El problema](docs/libro/01-el-problema.md) | Por qué la automatización iOS está rota |
 | [02 — Arquitectura](docs/libro/02-arquitectura.md) | AXUIElement, CGEvent, simctl, AppleScript |
-| [03 — La camara virtual](docs/libro/03-la-camara-virtual.md) | 10 intentos, 9 fracasos, y lo que aprendimos |
-| [04 — Inyeccion sin recompilar](docs/libro/04-inyeccion-sin-recompilar.md) | DYLD_INSERT_LIBRARIES en testing |
+| [03 — La cámara virtual](docs/libro/03-la-camara-virtual.md) | 10 intentos, 9 fracasos, y lo que aprendimos |
+| [04 — Inyección sin recompilar](docs/libro/04-inyeccion-sin-recompilar.md) | DYLD_INSERT_LIBRARIES en testing |
 | [05 — El editor](docs/libro/05-el-editor.md) | De CLI a IDE visual con Tauri + Monaco |
-| [06 — Alternativas](docs/libro/06-alternativas.md) | Maestro, Appium, AXe, XCUITest — analisis honesto |
-| [07 — Decisiones](docs/libro/07-decisiones.md) | Por que Swift, por que AX publicas, por que no YAML |
+| [06 — Alternativas](docs/libro/06-alternativas.md) | Maestro, Appium, AXe, XCUITest — análisis honesto |
+| [07 — Decisiones](docs/libro/07-decisiones.md) | Por qué Swift, por qué AX públicas, por qué no YAML |
 
 > **[Leer el libro completo →](docs/libro/README.md)**
 
 ---
 
-<h2 id="inicio-rapido">Inicio rapido</h2>
+<h2 id="inicio-rápido">Inicio rápido</h2>
 
 ```bash
 # Compilar
@@ -74,7 +74,7 @@ auto tree
 auto tap "General"
 ```
 
-### Camara virtual (sin recompilar)
+### Cámara virtual (sin recompilar)
 
 ```bash
 auto launch com.example.app --inject selfie.jpg
@@ -109,16 +109,16 @@ $ auto run login.auto
 
 ## Alternativas
 
-Si tu caso de uso es diferente, estas herramientas pueden ser mejor opcion:
+Si tu caso de uso es diferente, estas herramientas pueden ser mejor opción:
 
-| Caso | Herramienta | Por que |
+| Caso | Herramienta | Por qué |
 |---|---|---|
-| Multi-plataforma (iOS + Android) | [Maestro](https://maestro.dev) | YAML, setup rapido, CLI elegante |
-| Enterprise / equipo grande | [Appium](https://appium.io) | Estandar de industria, multi-lenguaje |
-| React Native | [Detox](https://wix.github.io/Detox/) | Sincronizacion con JS event loop |
+| Multi-plataforma (iOS + Android) | [Maestro](https://maestro.dev) | YAML, setup rápido, CLI elegante |
+| Enterprise / equipo grande | [Appium](https://appium.io) | Estándar de industria, multi-lenguaje |
+| React Native | [Detox](https://wix.github.io/Detox/) | Sincronización con JS event loop |
 | Solo iOS, sin dependencias | [AXe](https://github.com/cameroncooke/AXe) | Similar a AutoPilot, usa APIs privadas |
 
-Analisis completo: [Capitulo 6 — Alternativas](docs/libro/06-alternativas.md)
+Análisis completo: [Capítulo 6 — Alternativas](docs/libro/06-alternativas.md)
 
 ---
 

--- a/docs/libro/01-el-problema.md
+++ b/docs/libro/01-el-problema.md
@@ -1,34 +1,34 @@
-# Capitulo 1 — El problema
+# Capítulo 1 — El problema
 
-## La automatizacion iOS esta rota
+## La automatización iOS está rota
 
-Hay una pregunta que parece simple: ¿como hago tap en un boton del Simulador iOS desde la terminal?
+Hay una pregunta que parece simple: ¿cómo hago tap en un botón del Simulador iOS desde la terminal?
 
-La respuesta oficial de Apple es XCUITest. Escribes un test target en Swift, lo compilas junto con tu app, Xcode lanza el runner, el runner se conecta al Simulador, y ahi si — puedes hacer tap. Para una accion de 89 milisegundos, necesitas un proyecto de Xcode, un scheme de test, un build completo y un runner que compile cada vez que quieras ejecutar.
+La respuesta oficial de Apple es XCUITest. Escribes un test target en Swift, lo compilas junto con tu app, Xcode lanza el runner, el runner se conecta al Simulador, y ahí sí — puedes hacer tap. Para una acción de 89 milisegundos, necesitas un proyecto de Xcode, un scheme de test, un build completo y un runner que compile cada vez que quieras ejecutar.
 
-La respuesta de la comunidad es Appium. Instalas Node.js, el CLI de Appium, un driver de iOS que internamente usa WebDriverAgent (que a su vez es un wrapper de XCUITest), Java para Android, Python o Ruby para los clients, y un servidor HTTP que traduce el protocolo WebDriver W3C a acciones nativas. Para hacer tap en un boton, levantas un servidor.
+La respuesta de la comunidad es Appium. Instalas Node.js, el CLI de Appium, un driver de iOS que internamente usa WebDriverAgent (que a su vez es un wrapper de XCUITest), Java para Android, Python o Ruby para los clients, y un servidor HTTP que traduce el protocolo WebDriver W3C a acciones nativas. Para hacer tap en un botón, levantas un servidor.
 
-La respuesta de Maestro, la herramienta mas moderna del espacio, es un poco mas elegante. Escribes flujos en YAML, corres un CLI escrito en Kotlin, y por debajo — sin que lo sepas — Maestro lanza un XCUITest "zombie" que nunca termina y levanta un servidor HTTP interno. El matching de elementos lo hace Maestro en Kotlin despues de jalar el arbol de accesibilidad por HTTP.
+La respuesta de Maestro, la herramienta más moderna del espacio, es un poco más elegante. Escribes flujos en YAML, corres un CLI escrito en Kotlin, y por debajo — sin que lo sepas — Maestro lanza un XCUITest "zombie" que nunca termina y levanta un servidor HTTP interno. El matching de elementos lo hace Maestro en Kotlin después de jalar el árbol de accesibilidad por HTTP.
 
-Todas estas herramientas comparten una dependencia fundamental: **XCUITest**. Es el unico punto de acceso que Apple ofrece oficialmente para interactuar con la UI de una app iOS de forma programatica. Y XCUITest fue disenado para correr *dentro* del ecosistema de Xcode, no como una herramienta de linea de comandos.
+Todas estas herramientas comparten una dependencia fundamental: **XCUITest**. Es el único punto de acceso que Apple ofrece oficialmente para interactuar con la UI de una app iOS de forma programática. Y XCUITest fue diseñado para correr *dentro* del ecosistema de Xcode, no como una herramienta de línea de comandos.
 
 ## Lo que nadie te dice
 
-Hay cosas que descubres solo cuando intentas automatizar iOS en produccion, en CI/CD headless, a las 2 de la manana cuando el pipeline falla.
+Hay cosas que descubres solo cuando intentas automatizar iOS en producción, en CI/CD headless, a las 2 de la mañana cuando el pipeline falla.
 
-**No hay camara.** El Simulador iOS no tiene webcam. `AVCaptureDevice.default(.builtInWideAngleCamera, ...)` retorna `nil`. Si tu app usa la camara — escanear QR, tomar foto, verificar identidad — no la puedes probar en CI. Apple no ofrece solucion. Appium tampoco. Maestro tampoco. La unica opcion "oficial" es usar servicios cloud como BrowserStack que inyectan un modulo propietario en tu app por $400/mes.
+**No hay cámara.** El Simulador iOS no tiene webcam. `AVCaptureDevice.default(.builtInWideAngleCamera, ...)` retorna `nil`. Si tu app usa la cámara — escanear QR, tomar foto, verificar identidad — no la puedes probar en CI. Apple no ofrece solución. Appium tampoco. Maestro tampoco. La única opción "oficial" es usar servicios cloud como BrowserStack que inyectan un módulo propietario en tu app por $400/mes.
 
-**El arbol de accesibilidad es un ciudadano de segunda.** XCUITest tiene su propia forma de exponer elementos. Los botones de SwiftUI NavigationBar? `AXChildren = [0]`. Estan ahi visualmente pero el framework no los ve. Los placeholders de TextField en SwiftUI? Aparecen en `kAXValueAttribute`, no en `kAXTitleAttribute` ni `kAXDescriptionAttribute`. Cada version de iOS mueve cosas.
+**El árbol de accesibilidad es un ciudadano de segunda.** XCUITest tiene su propia forma de exponer elementos. Los botones de SwiftUI NavigationBar? `AXChildren = [0]`. Estan ahí visualmente pero el framework no los ve. Los placeholders de TextField en SwiftUI? Aparecen en `kAXValueAttribute`, no en `kAXTitleAttribute` ni `kAXDescriptionAttribute`. Cada versión de iOS mueve cosas.
 
-**El tiempo de setup es el enemigo silencioso.** Un ingeniero nuevo necesita entre 30 minutos y 2 horas para configurar Appium. Necesita entre 5 y 15 minutos para configurar un test target de XCUITest en un proyecto existente. Y si estas en CI, necesitas mantener esa configuracion viva — actualizar drivers cuando cambia Xcode, manejar timeouts de WebDriverAgent, lidiar con sesiones zombies.
+**El tiempo de setup es el enemigo silencioso.** Un ingeniero nuevo necesita entre 30 minutos y 2 horas para configurar Appium. Necesita entre 5 y 15 minutos para configurar un test target de XCUITest en un proyecto existente. Y si estas en CI, necesitas mantener esa configuración viva — actualizar drivers cuando cambia Xcode, manejar timeouts de WebDriverAgent, lidiar con sesiones zombies.
 
-## La observacion que lo cambio todo
+## La observación que lo cambió todo
 
 El Simulador iOS es una app de macOS. Se llama `Simulator.app`, tiene un PID, tiene una ventana. Y macOS tiene algo que pocas personas aprovechan para este caso de uso: las **APIs de Accesibilidad**.
 
-Cualquier aplicacion de macOS expone su interfaz a traves de `AXUIElement`. Es la misma API que usan los lectores de pantalla, los window managers, las herramientas de automatizacion de escritorio. No es nueva, no es experimental, no es privada. Esta documentada, es estable, y funciona en todas las versiones de macOS.
+Cualquier aplicacion de macOS expone su interfaz a traves de `AXUIElement`. Es la misma API que usan los lectores de pantalla, los window managers, las herramientas de automatización de escritorio. No es nueva, no es experimental, no es privada. Esta documentada, es estable, y funcióna en todas las versiones de macOS.
 
-Lo que descubrimos es que el Simulador iOS **renderiza las vistas de la app iOS como elementos nativos de accesibilidad de macOS**. Un `UIButton` con label "Login" en la app iOS aparece como un `AXButton` con `kAXTitleAttribute = "Login"` en el arbol de accesibilidad del Simulador.
+Lo que descubrimos es que el Simulador iOS **renderiza las vistas de la app iOS como elementos nativos de accesibilidad de macOS**. Un `UIButton` con label "Login" en la app iOS aparece como un `AXButton` con `kAXTitleAttribute = "Login"` en el árbol de accesibilidad del Simulador.
 
 ```mermaid
 sequenceDiagram
@@ -40,9 +40,9 @@ sequenceDiagram
 
     T->>A: auto tap "Login"
     A->>AX: AXUIElementCreateApplication(pid)
-    AX->>S: Leer arbol de accesibilidad
+    AX->>S: Leer árbol de accesibilidad
     S-->>AX: Elementos UI (botones, textos, campos)
-    AX-->>A: AXUIElement del boton "Login"
+    AX-->>A: AXUIElement del botón "Login"
     A->>AX: AXUIElementPerformAction(kAXPressAction)
     AX->>S: Ejecutar tap
     S->>iOS: Evento de toque
@@ -60,31 +60,31 @@ No una herramienta de testing. No un framework. No un producto.
 
 Un experimento: ¿hasta donde puedes llegar controlando el Simulador iOS *exclusivamente* desde macOS, sin tocar nada dentro del Simulador?
 
-La respuesta nos sorprendio. Pudimos:
-- Leer el arbol completo de UI de cualquier app
+La respuesta nos sorprendió. Pudimos:
+- Leer el árbol completo de UI de cualquier app
 - Hacer tap, scroll, swipe, long press, double tap
 - Escribir texto caracter por caracter
 - Simular Face ID (via menus nativos del Simulador)
 - Inyectar fotos al photo library
 - Manipular el portapapeles
-- Y lo mas inesperado: **inyectar un mock de camara en cualquier app sin recompilar**, algo que ninguna otra herramienta del mercado ofrece
+- Y lo más inesperado: **inyectar un mock de cámara en cualquier app sin recompilar**, algo que ningúna otra herramienta del mercado ofrece
 
-Cada una de estas capacidades trajo descubrimientos, tropiezos y decisiones de diseno que documentamos en detalle. La camara virtual en particular requirio **10 intentos** antes de encontrar un enfoque que funcionara — desde CMIOExtension (bloqueado por Apple) hasta dylib injection via `DYLD_INSERT_LIBRARIES` (que nadie usa en herramientas de testing).
+Cada una de estas capacidades trajo descubrimientos, tropiezos y decisiones de diseño que documentamos en detalle. La cámara virtual en particular requirió **10 intentos** antes de encontrar un enfoque que funciónara — desde CMIOExtension (bloqueado por Apple) hasta dylib injection via `DYLD_INSERT_LIBRARIES` (que nadie usa en herramientas de testing).
 
 Este libro documenta todo el proceso: los errores, los callejones sin salida, las decisiones y sus razones. No para vender AutoPilot — para que cualquier ingeniero que se enfrente a problemas similares tenga un punto de partida.
 
 ## Estructura de este libro
 
-| Capitulo | Que encontraras |
+| Capítulo | Qué encontrarás |
 |---|---|
-| [02 — Arquitectura](02-arquitectura.md) | Las 4 capas tecnicas: AXUIElement, CGEvent, simctl, AppleScript |
-| [03 — La camara virtual](03-la-camara-virtual.md) | 10 intentos, 9 fracasos, y lo que aprendimos de cada uno |
-| [04 — Inyeccion sin recompilar](04-inyeccion-sin-recompilar.md) | DYLD_INSERT_LIBRARIES en testing — un enfoque que nadie mas usa |
+| [02 — Arquitectura](02-arquitectura.md) | Las 4 capas técnicas: AXUIElement, CGEvent, simctl, AppleScript |
+| [03 — La cámara virtual](03-la-camara-virtual.md) | 10 intentos, 9 fracasos, y lo que aprendimos de cada uno |
+| [04 — Inyección sin recompilar](04-inyeccion-sin-recompilar.md) | DYLD_INSERT_LIBRARIES en testing — un enfoque que nadie más usa |
 | [05 — El editor](05-el-editor.md) | De CLI a IDE visual con Tauri + Monaco |
-| [06 — Alternativas](06-alternativas.md) | Maestro, Appium, AXe, XCUITest, idb — que hacen bien y por que elegimos otro camino |
-| [07 — Decisiones](07-decisiones.md) | Por que Swift puro, por que AX publicas, por que no YAML |
+| [06 — Alternativas](06-alternativas.md) | Maestro, Appium, AXe, XCUITest, idb — que hacen bien y por qué elegimos otro camino |
+| [07 — Decisiones](07-decisiones.md) | Por qué Swift puro, por qué AX públicas, por qué no YAML |
 | [Apendices](apendices/) | Referencia de comandos, variables de entorno, CI/CD, troubleshooting |
 
 ---
 
-*Siguiente: [Capitulo 2 — Arquitectura](02-arquitectura.md)*
+*Siguiente: [Capítulo 2 — Arquitectura](02-arquitectura.md)*

--- a/docs/libro/02-arquitectura.md
+++ b/docs/libro/02-arquitectura.md
@@ -1,4 +1,4 @@
-# Capitulo 2 — Arquitectura
+# Capítulo 2 — Arquitectura
 
 ## Cuatro capas, cero dependencias
 
@@ -6,10 +6,10 @@ Una vez que entiendes que el Simulador iOS es una app de macOS con accesibilidad
 
 AutoPilot se construye sobre 4 APIs de macOS. Cada una resuelve un problema distinto:
 
-| Capa | API | Que resuelve | Ejemplo |
+| Capa | API | Qué resuelve | Ejemplo |
 |---|---|---|---|
 | **Lectura** | AXUIElement | Ver la UI de la app | `auto tree`, `auto exists "Login"` |
-| **Entrada** | CGEvent | Simular interaccion humana | `auto type "Hola"`, `auto swipe up` |
+| **Entrada** | CGEvent | Simular interacción humana | `auto type "Hola"`, `auto swipe up` |
 | **Control** | xcrun simctl | Gestionar el Simulador | `auto launch`, `auto screenshot` |
 | **Menus** | AppleScript | Acceder a menus nativos | `auto faceid match` |
 
@@ -52,11 +52,11 @@ graph TB
     style macOS fill:#0a2540,color:#fff
 ```
 
-Lo que sigue es el detalle tecnico de cada capa. Si prefieres la vision general, salta a la [tabla resumen](#resumen) al final.
+Lo que sigue es el detalle técnico de cada capa. Si prefieres la vision general, salta a la [tabla resumen](#resumen) al final.
 
 ---
 
-> **Nota:** La documentacion tecnica completa de cada capa esta en [docs/ios/ARQUITECTURA.md](../ios/ARQUITECTURA.md). Este capitulo es un resumen narrativo con los hallazgos mas importantes.
+> **Nota:** La documentación técnica completa de cada capa esta en [docs/ios/ARQUITECTURA.md](../ios/ARQUITECTURA.md). Este capítulo es un resumen narrativo con los hallazgos más importantes.
 
 ---
 
@@ -64,32 +64,32 @@ Lo que sigue es el detalle tecnico de cada capa. Si prefieres la vision general,
 
 El descubrimiento fundamental: el Simulador renderiza las vistas de iOS como elementos nativos de accesibilidad de macOS.
 
-Cuando una app iOS muestra un boton con label "Login", el Simulador crea un `AXButton` con `kAXTitleAttribute = "Login"` en su arbol de accesibilidad. Esto no es una feature del Simulador — es un efecto secundario de como macOS renderiza ventanas.
+Cuando una app iOS muestra un botón con label "Login", el Simulador crea un `AXButton` con `kAXTitleAttribute = "Login"` en su árbol de accesibilidad. Esto no es una feature del Simulador — es un efecto secundario de como macOS renderiza ventanas.
 
 Para conectarse:
 
 ```
 NSWorkspace → buscar com.apple.iphonesimulator → obtener PID
     → AXUIElementCreateApplication(pid) → obtener ventana
-    → recorrer AXChildren recursivamente → arbol completo
+    → recorrer AXChildren recursivamente → árbol completo
 ```
 
 ### Hallazgos que no estan documentados en otro lugar
 
-- **El arbol no esta disponible inmediatamente.** Despues de activar el Simulador, los elementos tardan hasta 3 segundos en aparecer. AutoPilot reintenta 15 veces con intervalos de 200ms.
+- **El árbol no esta disponible inmediatamente.** Después de activar el Simulador, los elementos tardan hasta 3 segundos en aparecer. AutoPilot reintenta 15 veces con intervalos de 200ms.
 
-- **SwiftUI NavigationBar es invisible.** Los botones de la barra de navegacion de SwiftUI tienen `AXChildren = [0]`. Estan renderizados visualmente pero el framework de accesibilidad no los expone. Solucion: `tapAt` con coordenadas.
+- **SwiftUI NavigationBar es invisible.** Los botones de la barra de navegación de SwiftUI tienen `AXChildren = [0]`. Estan renderizados visualmente pero el framework de accesibilidad no los expone. Solución: `tapAt` con coordenadas.
 
 - **Los placeholders viven en Value, no en Title.** En SwiftUI, el texto placeholder de un `TextField` aparece en `kAXValueAttribute`, no en `kAXTitleAttribute` ni `kAXDescriptionAttribute`. Sin buscar en Value, campos de texto con placeholder son invisibles.
 
-- **La profundidad maxima importa.** Sin limite, la recursion puede colgarse en arboles muy profundos. AutoPilot limita a 20 niveles.
+- **La profundidad máxima importa.** Sin limite, la recursión puede colgarse en árboles muy profundos. AutoPilot limita a 20 niveles.
 
 ### Algoritmo de busqueda
 
-Encontrar el elemento correcto es critico. AutoPilot usa dos pasadas:
+Encontrar el elemento correcto es crítico. AutoPilot usa dos pasadas:
 
 1. **Match exacto** (toda la profundidad): identifier == query OR title == query OR label == query OR value == query
-2. **Match parcial** (toda la profundidad): label.contains(query), selecciona el mas corto (mas especifico)
+2. **Match parcial** (toda la profundidad): label.contains(query), selecciona el más corto (mas específico)
 
 Todas las comparaciones son case-insensitive.
 
@@ -103,7 +103,7 @@ AXUIElement puede hacer tap (`kAXPressAction`), pero no puede escribir texto, ni
 
 ### Hallazgos
 
-- **postToPid vs cghidEventTap.** `postToPid` envia el evento solo al Simulador — perfecto para escribir texto. `.post(tap: .cghidEventTap)` es global y alcanza UIs del sistema (photo picker, alertas de permisos). Cada accion usa el metodo correcto.
+- **postToPid vs cghidEventTap.** `postToPid` envia el evento solo al Simulador — perfecto para escribir texto. `.post(tap: .cghidEventTap)` es global y alcanza UIs del sistema (photo picker, alertas de permisos). Cada acción usa el método correcto.
 
 - **Swipe necesita movimiento suave.** Un salto directo de punto A a punto B no se reconoce como swipe. AutoPilot simula 20 pasos incrementales de drag con 15ms entre cada uno.
 
@@ -116,15 +116,15 @@ AXUIElement puede hacer tap (`kAXPressAction`), pero no puede escribir texto, ni
 `simctl` es la herramienta CLI de Apple para gestionar simuladores. AutoPilot la ejecuta como subproceso.
 
 Lo que agrega AutoPilot sobre simctl puro:
-- **Resolucion de nombre a UDID** — pasas "iPhone 16", AutoPilot busca el UDID
-- **Inyeccion de variables de entorno** — via prefijo `SIMCTL_CHILD_`
-- **Inyeccion de dylib** — via `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES` (Capitulo 4)
+- **Resolución de nombre a UDID** — pasas "iPhone 16", AutoPilot busca el UDID
+- **Inyección de variables de entorno** — via prefijo `SIMCTL_CHILD_`
+- **Inyección de dylib** — via `SIMCTL_CHILD_DYLD_INSERT_LIBRARIES` (Capítulo 4)
 
 ---
 
 ## Capa 4: AppleScript — El ultimo recurso
 
-Face ID no tiene API, ni en simctl ni en accesibilidad. Vive en el menu `Features > Face ID` del Simulador. La unica forma de acceder es automatizar el menu con AppleScript.
+Face ID no tiene API, ni en simctl ni en accesibilidad. Vive en el menu `Features > Face ID` del Simulador. La única forma de acceder es automatizar el menu con AppleScript.
 
 ```applescript
 tell application "System Events" to tell process "Simulator"
@@ -133,7 +133,7 @@ tell application "System Events" to tell process "Simulator"
 end tell
 ```
 
-Es fragil (depende del idioma del sistema y la estructura exacta del menu), pero es la unica opcion.
+Es frágil (depende del idioma del sistema y la estructura exacta del menu), pero es la única opción.
 
 ---
 
@@ -144,7 +144,7 @@ Terminal
     |
     auto tap "Login"
     |
-    ├─ Capa 1 (AXUIElement): Buscar "Login" en el arbol → encontrar AXButton
+    ├─ Capa 1 (AXUIElement): Buscar "Login" en el árbol → encontrar AXButton
     ├─ Capa 1 (AXUIElement): AXUIElementPerformAction(kAXPressAction)
     │   └─ Si falla: Capa 2 (CGEvent) → calcular centro → mouseDown + mouseUp
     |
@@ -161,8 +161,8 @@ Terminal
     └─ Capa 4 (AppleScript): click menu item "Matching Face" of menu "Face ID"...
 ```
 
-La documentacion tecnica completa con diagramas Mermaid de cada flujo esta en [docs/ios/ARQUITECTURA.md](../ios/ARQUITECTURA.md).
+La documentación técnica completa con diagramas Mermaid de cada flujo esta en [docs/ios/ARQUITECTURA.md](../ios/ARQUITECTURA.md).
 
 ---
 
-*Anterior: [Capitulo 1 — El problema](01-el-problema.md) | Siguiente: [Capitulo 3 — La camara virtual](03-la-camara-virtual.md)*
+*Anterior: [Capítulo 1 — El problema](01-el-problema.md) | Siguiente: [Capítulo 3 — La cámara virtual](03-la-camara-virtual.md)*

--- a/docs/libro/03-la-camara-virtual.md
+++ b/docs/libro/03-la-camara-virtual.md
@@ -1,110 +1,110 @@
-# Capitulo 3 — La camara virtual
+# Capítulo 3 — La cámara virtual
 
 ## 10 intentos, 9 fracasos
 
-El Simulador iOS no tiene camara. `AVCaptureDevice.default(.builtInWideAngleCamera, ...)` retorna `nil`. Para una app que escanea QR, toma selfies, o verifica identidad, esto significa que no se puede probar en CI/CD.
+El Simulador iOS no tiene cámara. `AVCaptureDevice.default(.builtInWideAngleCamera, ...)` retorna `nil`. Para una app que escanea QR, toma selfies, o verifica identidad, esto significa que no se puede probar en CI/CD.
 
-Apple no ofrece solucion. Appium tampoco. Maestro tampoco. BrowserStack cobra $400/mes por un servicio cloud que inyecta un modulo propietario en tu app.
+Apple no ofrece solución. Appium tampoco. Maestro tampoco. BrowserStack cobra $400/mes por un servicio cloud que inyecta un módulo propietario en tu app.
 
 Decidimos resolver esto nosotros. Nos tomo 10 intentos.
 
-> **Nota:** El diario de laboratorio completo (crudo, cronologico, con cada comando y cada error) esta en [camera/BITACORA.md](../../camera/BITACORA.md). Este capitulo es la version narrativa.
+> **Nota:** El diario de laboratorio completo (crudo, cronológico, con cada comando y cada error) esta en [camera/BITACORA.md](../../camera/BITACORA.md). Este capítulo es la versión narrativa.
 
 ---
 
-## Intento 1: CMIOExtension (camara virtual macOS)
+## Intento 1: CMIOExtension (cámara virtual macOS)
 
-**Hipotesis:** macOS permite registrar camaras virtuales via CoreMediaIO Extension. Si registramos una camara que envie frames de una imagen, el Simulador la veria como una webcam.
+**Hipótesis:** macOS permite registrar cámaras virtuales via CoreMediaIO Extension. Si registramos una cámara que envie frames de una imagen, el Simulador la veria como una webcam.
 
-**Que hicimos:** Implementamos CameraProvider, CameraDevice y CameraStream en Swift puro. La extension se embebe en una app contenedora (`AutoPilotCamera.app`). Compilacion exitosa.
+**Qué hicimos:** Implementamos CameraProvider, CameraDevice y CameraStream en Swift puro. La extension se embebe en una app contenedora (`AutoPilotCamera.app`). Compilación exitosa.
 
-**Por que fallo:** Apple bloquea las system extensions sin un entitlement especifico que hay que solicitar manualmente. `OSSystemExtensionRequest` requiere que la app este en `/Applications/`. El modo developer (`systemextensionsctl developer on`) requiere SIP deshabilitado. Y el camino legacy (DAL plugins) fue removido en macOS 15.
+**Por qué falló:** Apple bloquea las system extensions sin un entitlement específico que hay que solicitar manualmente. `OSSystemExtensionRequest` requiere que la app este en `/Applications/`. El modo developer (`systemextensionsctl developer on`) requiere SIP deshabilitado. Y el camino legacy (DAL plugins) fue removido en macOS 15.
 
-**Que aprendimos:** Apple controla el acceso a hardware virtual con mano dura. No hay workaround sin aprobacion explicita.
+**Qué aprendimos:** Apple controla el acceso a hardware virtual con mano dura. No hay workaround sin aprobación explícita.
 
 ---
 
 ## Intento 2: Webcam del Mac
 
-**Hipotesis:** El Mac tiene FaceTime HD y iPhone via Continuity Camera. Quizas el Simulador las puede ver.
+**Hipótesis:** El Mac tiene FaceTime HD y iPhone via Continuity Camera. Quizas el Simulador las puede ver.
 
-**Que hicimos:** Verificamos con `system_profiler SPCameraDataType`. Las camaras existen. El Simulador tiene `com.apple.display.captureservice` activo.
+**Qué hicimos:** Verificamos con `system_profiler SPCameraDataType`. Las cámaras existen. El Simulador tiene `com.apple.display.captureservice` activo.
 
-**Por que fallo:** El Simulador **no mapea** webcams de macOS a `AVCaptureSession` de apps iOS. `simctl privacy grant camera` no cambia nada — no hay hardware de camara que exponer.
+**Por qué falló:** El Simulador **no mapea** webcams de macOS a `AVCaptureSession` de apps iOS. `simctl privacy grant camera` no cambia nada — no hay hardware de cámara que exponer.
 
-**Que aprendimos:** El Simulador no es una VM completa. No virtualiza hardware de camara.
+**Qué aprendimos:** El Simulador no es una VM completa. No virtualiza hardware de cámara.
 
 ---
 
 ## Intento 3: Dylib injection (ObjC)
 
-**Hipotesis:** Si inyectamos una dylib via `DYLD_INSERT_LIBRARIES` que swizzlee `AVCaptureDevice`, `AVCaptureSession` y `AVCapturePhotoOutput`, podemos interceptar todo el pipeline de camara.
+**Hipótesis:** Si inyectamos una dylib via `DYLD_INSERT_LIBRARIES` que swizzlee `AVCaptureDevice`, `AVCaptureSession` y `AVCapturePhotoOutput`, podemos interceptar todo el pipeline de cámara.
 
-**Que funciono:**
+**Qué funciónó:**
 - Dylib ObjC compilada para iOS Simulator, cargada exitosamente
 - Swizzle de `authorizationStatus` → `.authorized`
 - Swizzle de `startRunning` → interceptado, evita crash
 - Swizzle de `capturePhoto:delegate:` → interceptado
 - Runtime introspection encuentra el selector `didFinishProcessingPhoto` en el delegate
 
-**Por que fallo:** `AVCapturePhoto` tiene `init` marcado `NS_UNAVAILABLE`. No se puede instanciar. Intentamos:
+**Por qué falló:** `AVCapturePhoto` tiene `init` marcado `NS_UNAVAILABLE`. No se puede instanciar. Intentamos:
 - `objc_msgSend(alloc, init)` → crash por ARM64 PAC (Pointer Authentication Code)
 - Subclase via `objc_allocateClassPair` → PAC valida el objeto interno
 - `object_getIvar` para acceder closure Swift → Swift closures no son ObjC blocks, distinta calling convention → `EXC_BAD_ACCESS`
 
-**Que aprendimos:** ObjC runtime puede interceptar llamadas pero no puede crear objetos Swift validos ni invocar closures Swift. La barrera entre ObjC y Swift es mas profunda de lo que parece.
+**Qué aprendimos:** ObjC runtime puede interceptar llamadas pero no puede crear objetos Swift validos ni invocar closures Swift. La barrera entre ObjC y Swift es más profunda de lo que parece.
 
 ---
 
 ## Intento 4: Variables de entorno
 
-**Resultado:** Funciona. Pero requiere modificar el codigo de la app.
+**Resultado:** Funciona. Pero requiere modificar el código de la app.
 
-11 lineas en la app leen `AUTOPILOT_CAMERA_IMAGE` del environment y retornan esa imagen cuando se llama `capturePhoto`. Simple, determinista, rapido.
+11 líneas en la app leen `AUTOPILOT_CAMERA_IMAGE` del environment y retornan esa imagen cuando se llama `capturePhoto`. Simple, determinista, rápido.
 
 **Hallazgo inesperado:** `/tmp/` del Simulador NO es `/tmp/` del Mac — tienen filesystems separados. Pero el proceso de la app SI corre como proceso macOS y SI puede leer rutas absolutas del Mac.
 
-**Limitacion:** Solo funciona si controlas el codigo. Para apps de terceros, no aplica.
+**Limitación:** Solo funcióna si controlas el código. Para apps de terceros, no aplica.
 
 ---
 
 ## Intento 5: Swift dylib
 
-**Hipotesis:** Si la dylib esta escrita en Swift (no ObjC), puede crear objetos Swift validos y llamar closures directamente.
+**Hipótesis:** Si la dylib esta escrita en Swift (no ObjC), puede crear objetos Swift validos y llamar closures directamente.
 
-**Que funciono:** El swizzle de todos los metodos. La carga de imagen. La interceptacion de `capturePhoto`.
+**Qué funciónó:** El swizzle de todos los métodos. La carga de imagen. La interceptación de `capturePhoto`.
 
-**Por que fallo:** Acceder al ivar `onPhotoCaptured` del CameraManager via `ivar_getOffset` + `assumingMemoryBound(to:)` crashea. Las closures Swift en memoria no son function pointers simples — tienen contexto capturado + metadata que no se puede reinterpretar como `(UIImage) -> Void`.
+**Por qué falló:** Acceder al ivar `onPhotoCaptured` del CameraManager via `ivar_getOffset` + `assumingMemoryBound(to:)` crashea. Las closures Swift en memoria no son function pointers simples — tienen contexto capturado + metadata que no se puede reinterpretar como `(UIImage) -> Void`.
 
-**Que aprendimos:** No es PAC. Es la ABI de Swift closures. El layout en memoria de una closure Swift es opaco y no esta documentado publicamente.
+**Qué aprendimos:** No es PAC. Es la ABI de Swift closures. El layout en memoria de una closure Swift es opaco y no esta documentado publicamente.
 
 ---
 
 ## Intento 6: Package con callback registrado
 
-**Resultado:** Funciona. La app necesita 1 linea.
+**Resultado:** Funciona. La app necesita 1 línea.
 
 En vez de buscar el callback via introspection, la app registra `AutoPilotCamera.onPhotoCaptured = callback`. El swizzle lo invoca directamente. Probado end-to-end: imagen inyectada, "Fotos capturadas 1".
 
-**Limitacion:** Requiere que la app dependa del package. No funciona con apps de terceros.
+**Limitación:** Requiere que la app dependa del package. No funcióna con apps de terceros.
 
 ---
 
 ## Intento 7: Pre-build script
 
-**Hipotesis:** Un script de Xcode pre-build reemplaza `AVCaptureDevice` → `AutoPilotCaptureDevice` en todos los archivos fuente. Post-build restaura.
+**Hipótesis:** Un script de Xcode pre-build reemplaza `AVCaptureDevice` → `AutoPilotCaptureDevice` en todos los archivos fuente. Post-build restaura.
 
-**Que funciono:** Los archivos del proyecto principal se reemplazan correctamente.
+**Qué funciónó:** Los archivos del proyecto principal se reemplazan correctamente.
 
-**Por que fallo:** No alcanza dependencias SPM. Solo modifica archivos del workspace. Ademas, conflictos de tipos: `AVCaptureDevice.default(for:)` retorna el tipo real, pero nuestro wrapper espera otro tipo.
+**Por qué falló:** No alcanza dependencias SPM. Solo modifica archivos del workspace. Además, conflictos de tipos: `AVCaptureDevice.default(for:)` retorna el tipo real, pero nuestro wrapper espera otro tipo.
 
 ---
 
 ## Intento 8: VFS overlay + module map
 
-**Hipotesis:** Usar un Virtual Filesystem overlay para reemplazar los headers de AVFoundation con versiones custom que incluyan nuestras clases mock.
+**Hipótesis:** Usar un Virtual Filesystem overlay para reemplazar los headers de AVFoundation con versiones custom que incluyan nuestras clases mock.
 
-**Por que fallo:** Los headers de AVFoundation son interdependientes. Simplificar un header rompe otros — tipos como `AVCaptureConnection` faltan y causan errores en cadena. Mantener headers custom completos es inviable por la superficie de API.
+**Por qué falló:** Los headers de AVFoundation son interdependientes. Simplificar un header rompe otros — tipos como `AVCaptureConnection` faltan y causan errores en cadena. Mantener headers custom completos es inviable por la superficie de API.
 
 ---
 
@@ -114,30 +114,30 @@ En vez de buscar el callback via introspection, la app registra `AutoPilotCamera
 
 Este fue el momento eureka.
 
-El problema central de los intentos 3 y 5 era que `AVCapturePhoto` tiene `init` marcado como no disponible. Pero esa restriccion es *solo de compilador*, no de runtime. El macro `AV_INIT_UNAVAILABLE` esta definido en `AVBase.h`.
+El problema central de los intentos 3 y 5 era que `AVCapturePhoto` tiene `init` marcado como no disponible. Pero esa restricción es *solo de compilador*, no de runtime. El macro `AV_INIT_UNAVAILABLE` esta definido en `AVBase.h`.
 
-La solucion:
+La solución:
 
 ```objc
 // Importar AVBase.h primero (define AV_INIT_UNAVAILABLE)
 #import <AVFoundation/AVBase.h>
 
-// Eliminar la restriccion
+// Eliminar la restricción
 #undef AV_INIT_UNAVAILABLE
 #define AV_INIT_UNAVAILABLE
 
 // Ahora importar AVFoundation — init de AVCapturePhoto esta disponible
 #import <AVFoundation/AVFoundation.h>
 
-// Esto funciona:
+// Esto funcióna:
 AVCapturePhoto *photo = [[AVCapturePhoto alloc] init];
 ```
 
 Con init disponible, podemos crear instancias reales de `AVCapturePhoto` y guardar datos via `objc_setAssociatedObject` — sin tocar ivars internos, sin PAC issues.
 
-El codigo se compila a una static library de ~28KB y se inyecta via `-force_load` en el `OTHER_LDFLAGS` de xcodebuild. El constructor `__attribute__((constructor))` swizzlea ~25 metodos al cargar.
+El código se compila a una static library de ~28KB y se inyecta via `-force_load` en el `OTHER_LDFLAGS` de xcodebuild. El constructor `__attribute__((constructor))` swizzlea ~25 métodos al cargar.
 
-**Metodos swizzleados:**
+**Métodos swizzleados:**
 - AVCaptureDevice: authorizationStatus, requestAccess, defaultDevice (2 variantes)
 - AVCaptureDeviceInput: initWithDevice, deviceInputWithDevice
 - AVCaptureSession: startRunning, stopRunning, isRunning, canAdd/add/remove Input/Output, begin/commitConfiguration, inputs, outputs
@@ -146,9 +146,9 @@ El codigo se compila a una static library de ~28KB y se inyecta via `-force_load
 - AVCaptureMetadataOutput: setMetadataObjectsDelegate, setMetadataObjectTypes
 - AVCaptureVideoPreviewLayer: setSession (muestra preview con labels "LIVE" + "AutoPilot | Mock Camera")
 
-**Gotcha:** `class_addMethod` vs `method_setImplementation`. Si el metodo esta heredado (no directamente en la clase), `method_setImplementation` modifica la *superclase*. `class_addMethod` lo agrega directamente a la subclase. Esto causo bugs sutiles hasta que lo entendimos.
+**Gotcha:** `class_addMethod` vs `method_setImplementation`. Si el método esta heredado (no directamente en la clase), `method_setImplementation` modifica la *superclase*. `class_addMethod` lo agrega directamente a la subclase. Esto causo bugs sutiles hasta que lo entendimos.
 
-**Gotcha:** Xcode 26 requiere `ENABLE_DEBUG_DYLIB=NO` para que `-force_load` funcione en el binario principal.
+**Gotcha:** Xcode 26 requiere `ENABLE_DEBUG_DYLIB=NO` para que `-force_load` funcióne en el binario principal.
 
 ---
 
@@ -156,9 +156,9 @@ El codigo se compila a una static library de ~28KB y se inyecta via `-force_load
 
 **Resultado:** FUNCIONA. Sin proyecto Xcode. Con hot-swap.
 
-El mismo codigo ObjC del intento 9 se compila como dylib en vez de static library, se cachea, y se inyecta via `DYLD_INSERT_LIBRARIES` al lanzar la app.
+El mismo código ObjC del intento 9 se compila como dylib en vez de static library, se cachea, y se inyecta via `DYLD_INSERT_LIBRARIES` al lanzar la app.
 
-Este intento se convirtio en un capitulo completo: [Capitulo 4 — Inyeccion sin recompilar](04-inyeccion-sin-recompilar.md).
+Este intento se convirtio en un capítulo completo: [Capítulo 4 — Inyección sin recompilar](04-inyeccion-sin-recompilar.md).
 
 ---
 
@@ -168,29 +168,29 @@ Este intento se convirtio en un capitulo completo: [Capitulo 4 — Inyeccion sin
 Intento  Enfoque                          Resultado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   1      CMIOExtension                    Bloqueado (entitlement Apple)
-  2      Webcam del Mac                   No funciona (no hay mapeo)
+  2      Webcam del Mac                   No funcióna (no hay mapeo)
   3      Dylib ObjC                       Parcial (PAC bloquea objetos)
   4      Variables de entorno             Funciona (requiere modificar app)
   5      Swift dylib                      Parcial (ABI closures)
-  6      Package + callback               Funciona (requiere 1 linea)
+  6      Package + callback               Funciona (requiere 1 línea)
   7      Pre-build script                 Parcial (no alcanza SPM deps)
-  8      VFS overlay + module map         No funciona (headers rotos)
+  8      VFS overlay + module map         No funcióna (headers rotos)
   9      force_load + #undef              FUNCIONA (sin modificar app) ←
   10     DYLD_INSERT_LIBRARIES            FUNCIONA (sin recompilar)   ←
 ```
 
-## Que aprendimos (meta-lecciones)
+## Qué aprendimos (meta-lecciones)
 
-1. **Las restricciones de compilador no son restricciones de runtime.** `AV_INIT_UNAVAILABLE` es un macro que desaparece despues de compilar. El runtime no sabe que init estaba "prohibido".
+1. **Las restricciones de compilador no son restricciones de runtime.** `AV_INIT_UNAVAILABLE` es un macro que desaparece después de compilar. El runtime no sabe que init estaba "prohibido".
 
 2. **Associated objects son la herramienta correcta.** En vez de tocar ivars internos (que rompe con PAC), `objc_setAssociatedObject` permite guardar datos en cualquier objeto sin conocer su layout interno.
 
 3. **Las ABI boundaries son reales.** ObjC y Swift comparten el runtime de Objective-C, pero las closures de Swift y los layouts de memoria son opacos. No asumas que puedes cruzar la frontera con casting.
 
-4. **Apple protege el hardware virtual.** CMIOExtension, DAL plugins, webcam mapping — todo requiere permisos especiales o esta deprecado. La solucion fue no virtualizar hardware, sino interceptar el software.
+4. **Apple protege el hardware virtual.** CMIOExtension, DAL plugins, webcam mapping — todo requiere permisos especiales o esta deprecado. La solución fue no virtualizar hardware, sino interceptar el software.
 
-5. **Los intentos fallidos no son tiempo perdido.** Cada intento nos ensenó algo que uso el siguiente. El intento 3 nos enseno el swizzle, el 5 nos enseno los limites de Swift ABI, el 9 resolvio el problema de init — sin los 8 fracasos anteriores, el 9 no habria existido.
+5. **Los intentos fallidos no son tiempo perdido.** Cada intento nos enseñó algo que uso el siguiente. El intento 3 nos enseno el swizzle, el 5 nos enseno los limites de Swift ABI, el 9 resolvio el problema de init — sin los 8 fracasos anteriores, el 9 no habria existido.
 
 ---
 
-*Anterior: [Capitulo 2 — Arquitectura](02-arquitectura.md) | Siguiente: [Capitulo 4 — Inyeccion sin recompilar](04-inyeccion-sin-recompilar.md)*
+*Anterior: [Capítulo 2 — Arquitectura](02-arquitectura.md) | Siguiente: [Capítulo 4 — Inyección sin recompilar](04-inyeccion-sin-recompilar.md)*

--- a/docs/libro/04-inyeccion-sin-recompilar.md
+++ b/docs/libro/04-inyeccion-sin-recompilar.md
@@ -1,24 +1,24 @@
-# Capitulo 4 — Inyeccion sin recompilar
+# Capítulo 4 — Inyección sin recompilar
 
-## Un enfoque que nadie mas usa
+## Un enfoque que nadie más usa
 
-Despues de 9 intentos para resolver la camara virtual (Capitulo 3), teniamos una solucion funcional: `auto build` compila una static library ObjC y la inyecta via `-force_load`. Funciona con cualquier app, swizzlea 25 metodos de AVFoundation, y la app recibe fotos inyectadas como si vinieran de una camara real.
+Después de 9 intentos para resolver la cámara virtual (Capítulo 3), teníamos una solución funciónal: `auto build` compila una static library ObjC y la inyecta via `-force_load`. Funciona con cualquier app, swizzlea 25 métodos de AVFoundation, y la app recibe fotos inyectadas como si vinieran de una cámara real.
 
 Pero tenia un problema: **necesitas el proyecto Xcode**.
 
-Si alguien te pasa un `.app` ya compilado, o si quieres probar una app de terceros, o si estas en CI y no quieres recompilar cada vez que cambias la imagen de la camara — `auto build` no te sirve.
+Si alguien te pasa un `.app` ya compilado, o si quieres probar una app de terceros, o si estas en CI y no quieres recompilar cada vez que cambias la imagen de la cámara — `auto build` no te sirve.
 
 La pregunta era: ¿se puede inyectar el mock en una app que ya esta instalada en el Simulador, sin tocarla?
 
 ## DYLD_INSERT_LIBRARIES
 
-macOS tiene un mecanismo de inyeccion de codigo a nivel de dynamic linker: `DYLD_INSERT_LIBRARIES`. Al setear esta variable de entorno antes de lanzar un proceso, `dyld` carga la dylib especificada *junto con* el binario principal. El codigo de la dylib se ejecuta antes que `main()`.
+macOS tiene un mecanismo de inyección de código a nivel de dynamic linker: `DYLD_INSERT_LIBRARIES`. Al setear esta variable de entorno antes de lanzar un proceso, `dyld` carga la dylib específicada *junto con* el binario principal. El código de la dylib se ejecuta antes que `main()`.
 
-En seguridad, esto se usa para interceptar funciones (hooking). En desarrollo, Apple lo usa para herramientas como AddressSanitizer. En testing de iOS, **nadie lo usa**. Revisamos la documentacion de Maestro, Appium, Detox, AXe, idb, EarlGrey — ninguno menciona `DYLD_INSERT_LIBRARIES` como mecanismo de inyeccion.
+En seguridad, esto se usa para interceptar funciónes (hooking). En desarrollo, Apple lo usa para herramientas como AddressSanitizer. En testing de iOS, **nadie lo usa**. Revisamos la documentación de Maestro, Appium, Detox, AXe, idb, EarlGrey — ninguno menciona `DYLD_INSERT_LIBRARIES` como mecanismo de inyección.
 
-### Por que funciona en el Simulador
+### Por qué funcióna en el Simulador
 
-Las apps del Simulador iOS corren como procesos de macOS. No tienen code signing enforcement como en un dispositivo fisico. `dyld` acepta la variable de entorno sin restricciones.
+Las apps del Simulador iOS corren como procesos de macOS. No tienen code signing enforcement como en un dispositivo físico. `dyld` acepta la variable de entorno sin restricciones.
 
 `simctl` tiene un prefijo especial: cualquier variable de entorno con prefijo `SIMCTL_CHILD_` se pasa al proceso de la app sin el prefijo. Es decir:
 
@@ -28,13 +28,13 @@ SIMCTL_CHILD_DYLD_INSERT_LIBRARIES=/path/to/lib.dylib xcrun simctl launch booted
 
 La app arranca con `DYLD_INSERT_LIBRARIES=/path/to/lib.dylib`, `dyld` carga la dylib, y el `__attribute__((constructor))` se ejecuta antes que `main()`.
 
-### Por que NO funciona en dispositivo fisico
+### Por qué NO funcióna en dispositivo físico
 
-En un iPhone real, iOS verifica code signing de todas las librerias cargadas. ARM64 PAC (Pointer Authentication Codes) valida la integridad de punteros de funcion. Una dylib no firmada por Apple o por el desarrollador es rechazada. Esto es una limitacion fundamental — la inyeccion solo funciona en Simulador.
+En un iPhone real, iOS verifica code signing de todas las librerias cargadas. ARM64 PAC (Pointer Authentication Codes) valida la integridad de punteros de función. Una dylib no firmada por Apple o por el desarrollador es rechazada. Esto es una limitación fundamental — la inyección solo funcióna en Simulador.
 
 ## Compilar el mock como dylib
 
-El mismo codigo ObjC de MockHeaders.swift (534 lineas, 25 metodos swizzleados) que usabamos como static library se puede compilar como dylib:
+El mismo código ObjC de MockHeaders.swift (534 líneas, 25 métodos swizzleados) que usábamos como static library se puede compilar como dylib:
 
 ```bash
 xcrun clang -dynamiclib -arch arm64 \
@@ -50,7 +50,7 @@ El resultado es una dylib de ~75KB que se cachea en `~/.autopilot/` y se reutili
 
 ### Tropiezo: QuartzCore faltante
 
-La primera compilacion fallo:
+La primera compilación falló:
 
 ```
 Undefined symbols for architecture arm64:
@@ -58,19 +58,19 @@ Undefined symbols for architecture arm64:
   "_kCAGravityResize", referenced from: _ap_previewSetSession
 ```
 
-`CACurrentMediaTime()` y `kCAGravityResize` vienen de QuartzCore. Con `-force_load` no era problema porque el binario final de la app ya linkea QuartzCore. Con `-dynamiclib`, la dylib necesita declarar todas sus dependencias explicitamente. Solucion: agregar `-framework QuartzCore`.
+`CACurrentMediaTime()` y `kCAGravityResize` vienen de QuartzCore. Con `-force_load` no era problema porque el binario final de la app ya linkea QuartzCore. Con `-dynamiclib`, la dylib necesita declarar todas sus dependencias explícitamente. Solución: agregar `-framework QuartzCore`.
 
 ## Hot-swap: cambiar la imagen sin relanzar
 
 Con `auto build` (force-load), la imagen se lee del environment variable `AUTOPILOT_CAMERA_IMAGE`. Esta variable se setea una vez al lanzar la app y no cambia. Si quieres otra imagen, relanzas.
 
-Con dylib injection, descubrimos que podiamos hacer algo mejor.
+Con dylib injection, descubrimos que podíamos hacer algo mejor.
 
 ### El problema
 
 Las variables de entorno son inmutables post-launch. `[NSProcessInfo processInfo].environment` retorna un snapshot del momento en que el proceso arranco. No hay forma de cambiar `AUTOPILOT_CAMERA_IMAGE` desde fuera una vez que la app esta corriendo.
 
-### La solucion: un path fijo
+### La solución: un path fijo
 
 En vez de leer de una variable de entorno, el mock lee de un **archivo en una ubicacion fija**: `/tmp/autopilot-camera-image.jpg`. Cada vez que la app llama `capturePhoto`, el mock lee el archivo en ese momento — no lo cachea.
 
@@ -98,7 +98,7 @@ Un descubrimiento temprano (Intento 4 en la bitacora) fue que `/tmp/` del Simula
 
 ### Tropiezo: constructor condicionado
 
-El constructor original de MockHeaders solo activaba el swizzle si existia la variable `AUTOPILOT_CAMERA_IMAGE`:
+El constructor original de MockHeaders solo activaba el swizzle si existía la variable `AUTOPILOT_CAMERA_IMAGE`:
 
 ```objc
 if (!imagePath && !qrCode) {
@@ -107,7 +107,7 @@ if (!imagePath && !qrCode) {
 }
 ```
 
-Con dylib injection, la dylib SOLO se carga cuando el usuario pide `--inject`. Si la dylib esta presente, siempre debe activar el swizzle — la imagen puede llegar despues via `auto inject`. Solucion: remover la condicion.
+Con dylib injection, la dylib SOLO se carga cuando el usuario pide `--inject`. Si la dylib esta presente, siempre debe activar el swizzle — la imagen puede llegar después via `auto inject`. Solución: remover la condicion.
 
 ## El flujo final
 
@@ -115,7 +115,7 @@ Con dylib injection, la dylib SOLO se carga cuando el usuario pide `--inject`. S
 # Lanzar app con mock inyectado
 auto launch com.example.app --inject selfie.jpg
 
-# La app muestra selfie.jpg en el preview de camara
+# La app muestra selfie.jpg en el preview de cámara
 # El usuario toca "Capturar" → recibe selfie.jpg
 
 # Cambiar imagen sin relanzar
@@ -128,7 +128,7 @@ En un script `.auto`:
 
 ```bash
 launch com.example.app --inject selfie.jpg
-waitFor "Camara lista" 10
+waitFor "Cámara lista" 10
 tap "Capturar Foto"
 screenshot resultado-1.png
 
@@ -151,24 +151,24 @@ Tres fotos, tres imagenes diferentes, una sola sesion de la app, sin relanzar.
 | Modifica el binario | No (dylib externa) | Si (linkada al binario) |
 | Hot-swap de imagen | Si (`auto inject`) | No (relanzar) |
 | Mecanismo | `DYLD_INSERT_LIBRARIES` | `-force_load` |
-| Tamano | ~75KB dylib cacheada | ~28KB static lib (por build) |
-| Funciona en device fisico | No (code signing) | No (solo Simulador) |
-| Compilacion | Una vez | Cada build |
+| Tamaño | ~75KB dylib cacheada | ~28KB static lib (por build) |
+| Funciona en device físico | No (code signing) | No (solo Simulador) |
+| Compilación | Una vez | Cada build |
 
 No es que uno sea mejor que el otro. Son complementarios. Si tienes el proyecto Xcode y quieres el mock integrado en el binario, usa `auto build`. Si quieres probar una app ya instalada o cambiar imagenes en caliente, usa `launch --inject`.
 
-## Que aprendimos
+## Qué aprendimos
 
-1. **`DYLD_INSERT_LIBRARIES` es una herramienta de testing viable** — nadie la usa para esto, pero funciona perfectamente en el Simulador.
+1. **`DYLD_INSERT_LIBRARIES` es una herramienta de testing viable** — nadie la usa para esto, pero funcióna perfectamente en el Simulador.
 
-2. **Las apps del Simulador son procesos de macOS** — comparten `/tmp/`, aceptan dylibs, no tienen code signing enforcement. Esto abre posibilidades que no existen en dispositivos fisicos.
+2. **Las apps del Simulador son procesos de macOS** — comparten `/tmp/`, aceptan dylibs, no tienen code signing enforcement. Esto abre posibilidades que no existen en dispositivos físicos.
 
 3. **Las variables de entorno son inmutables post-launch** — si necesitas cambiar estado desde fuera, usa archivos en disco, no env vars.
 
-4. **`-dynamiclib` requiere dependencias explicitas** — a diferencia de static libs que resuelven dependencias al linkear con el binario final.
+4. **`-dynamiclib` requiere dependencias explícitas** — a diferencia de static libs que resuelven dependencias al linkear con el binario final.
 
-5. **El hot-swap cambia la ergonomia de testing** — poder cambiar la imagen de camara sin relanzar la app permite scripts de prueba mas ricos y realistas.
+5. **El hot-swap cambia la ergonomía de testing** — poder cambiar la imagen de cámara sin relanzar la app permite scripts de prueba más ricos y realistas.
 
 ---
 
-*Anterior: [Capitulo 3 — La camara virtual](03-la-camara-virtual.md) | Siguiente: [Capitulo 5 — El editor](05-el-editor.md)*
+*Anterior: [Capítulo 3 — La cámara virtual](03-la-camara-virtual.md) | Siguiente: [Capítulo 5 — El editor](05-el-editor.md)*

--- a/docs/libro/05-el-editor.md
+++ b/docs/libro/05-el-editor.md
@@ -1,26 +1,26 @@
-# Capitulo 5 — El editor
+# Capítulo 5 — El editor
 
 ## De CLI a IDE visual
 
 AutoPilot empezo como un binario de terminal. Escribias `auto tap "Login"`, veias el resultado, escribias el siguiente comando. Funcionaba, pero tenia dos problemas:
 
-**No veias lo que pasaba.** Hacias tap en "Login" y el CLI te decia "Tapped 'Login' (89ms)". Pero ¿donde estaba el boton? ¿Que mas habia en pantalla? ¿El tap fue en el elemento correcto? Para saberlo, tenias que cambiar a la ventana del Simulador, verificar visualmente, y volver a la terminal.
+**No veias lo que pasaba.** Hacias tap en "Login" y el CLI te decia "Tapped 'Login' (89ms)". Pero ¿donde estaba el botón? ¿Qué más habia en pantalla? ¿El tap fue en el elemento correcto? Para saberlo, tenias que cambiar a la ventana del Simulador, verificar visualmente, y volver a la terminal.
 
-**Escribir scripts era a ciegas.** Un script `.auto` es una secuencia de comandos. Pero para escribirlo necesitabas saber los labels exactos de los elementos, su jerarquia, y si existian en el momento correcto. El ciclo era: escribir comando, correr, fallar, inspeccionar con `auto tree`, corregir, repetir.
+**Escribir scripts era a ciegas.** Un script `.auto` es una secuencia de comandos. Pero para escribirlo necesitabas saber los labels exactos de los elementos, su jerarquía, y si existían en el momento correcto. El ciclo era: escribir comando, correr, fallar, inspeccionar con `auto tree`, corregir, repetir.
 
-La solucion era obvia: un editor que mostrara el Simulador y el arbol de accesibilidad en tiempo real, junto al script que estas escribiendo.
+La solución era obvia: un editor que mostrara el Simulador y el árbol de accesibilidad en tiempo real, junto al script que estas escribiendo.
 
 ## Stack
 
-Consideramos tres opciones (documentado en [Capitulo 7, ADR 5](07-decisiones.md)):
+Consideramos tres opciones (documentado en [Capítulo 7, ADR 5](07-decisiones.md)):
 
-- **Electron:** El estandar. ~200MB. JavaScript everywhere.
-- **SwiftUI nativa:** El natural para un proyecto Swift. Pero no tiene un editor de codigo comparable a Monaco.
+- **Electron:** El estándar. ~200MB. JavaScript everywhere.
+- **SwiftUI nativa:** El natural para un proyecto Swift. Pero no tiene un editor de código comparable a Monaco.
 - **Tauri:** Rust backend + webview nativo. ~15MB. React + Monaco para el frontend.
 
 Elegimos Tauri. El editor pesa ~15MB (13x menos que Electron), el backend en Rust puede llamar al CLI directamente, y Monaco nos da syntax highlighting, autocomplete, y temas oscuros gratis.
 
-## Que hace
+## Qué hace
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -54,13 +54,13 @@ Elegimos Tauri. El editor pesa ~15MB (13x menos que Electron), el backend en Rus
 El editor reconoce el lenguaje `.auto`:
 - **Keywords:** `launch`, `tap`, `type`, `waitFor`, `screenshot`, `inject`, etc.
 - **Strings:** entre comillas dobles o simples
-- **Comentarios:** lineas que empiezan con `#`
-- **Numeros:** timeouts, indices
+- **Comentarios:** líneas que empiezan con `#`
+- **Números:** timeouts, índices
 - Tema oscuro "AutoPilot" basado en Tokyo Night
 
 ### Autocomplete
 
-35+ comandos con snippets. Pero lo interesante es que tambien autocompleta **elementos del Simulador en tiempo real**. El editor llama `auto tree` periodicamente y ofrece los labels de los elementos visibles como sugerencias.
+35+ comandos con snippets. Pero lo interesante es que también autocompleta **elementos del Simulador en tiempo real**. El editor llama `auto tree` periodicamente y ofrece los labels de los elementos visibles como sugerencias.
 
 ### Inspector
 
@@ -68,7 +68,7 @@ Dos vistas:
 
 **Preview:** Screenshot real del Simulador con overlays semi-transparentes sobre cada elemento. Click en un overlay inserta el comando `tap "Label"` en el editor.
 
-**Tree:** Arbol jerarquico con indice `$N`, tipo (AXButton, AXTextField...), label, y coordenadas. Los indices `$N` se pueden usar en scripts: `tap $3` es equivalente a `tap "Usuario"`.
+**Tree:** Arbol jerárquico con índice `$N`, tipo (AXButton, AXTextField...), label, y coordenadas. Los índices `$N` se pueden usar en scripts: `tap $3` es equivalente a `tap "Usuario"`.
 
 ### Auto-wait
 
@@ -76,7 +76,7 @@ Entre cada paso de un script, el editor usa `AXObserver` para detectar cuando la
 
 ### Duplicados
 
-Si una pantalla tiene dos elementos "Camera", `auto tap "Camera"` tapea el primero. `auto tap "Camera[2]"` tapea el segundo. El indice se resuelve en el orden del arbol AX — el mismo orden que UIAutomator usa en Android, lo que lo hace cross-platform.
+Si una pantalla tiene dos elementos "Camera", `auto tap "Camera"` tapea el primero. `auto tap "Camera[2]"` tapea el segundo. El índice se resuelve en el orden del árbol AX — el mismo orden que UIAutomator usa en Android, lo que lo hace cross-platform.
 
 ## Arquitectura
 
@@ -95,18 +95,18 @@ editor/
 │           └── inspect     # Atributos de un elemento
 ```
 
-El frontend usa `invoke()` de Tauri para llamar al backend Rust. El backend ejecuta el binario `auto` como subproceso y parsea su output. No hay servidor HTTP ni WebSocket — la comunicacion es via IPC de Tauri.
+El frontend usa `invoke()` de Tauri para llamar al backend Rust. El backend ejecuta el binario `auto` como subproceso y parsea su output. No hay servidor HTTP ni WebSocket — la comúnicación es via IPC de Tauri.
 
-## Que aprendimos
+## Qué aprendimos
 
-1. **Monaco es absurdamente bueno.** Syntax highlighting, autocomplete con snippets, themes, multi-cursor — todo funciona out of the box. Implementar algo comparable en SwiftUI habria tomado meses.
+1. **Monaco es absurdamente bueno.** Syntax highlighting, autocomplete con snippets, themes, multi-cursor — todo funcióna out of the box. Implementar algo comparable en SwiftUI habria tomado meses.
 
-2. **AXObserver es la clave del auto-wait.** Registrar un observer en el Simulador y esperar a que deje de emitir eventos es mucho mas robusto que `sleep` o polling con `waitFor`.
+2. **AXObserver es la clave del auto-wait.** Registrar un observer en el Simulador y esperar a que deje de emitir eventos es mucho más robusto que `sleep` o polling con `waitFor`.
 
-3. **El inspector cambia la forma de escribir scripts.** Ver los elementos en tiempo real con sus labels y coordenadas elimina el ciclo de prueba-y-error que teniamos con el CLI puro.
+3. **El inspector cambia la forma de escribir scripts.** Ver los elementos en tiempo real con sus labels y coordenadas elimina el ciclo de prueba-y-error que teníamos con el CLI puro.
 
-4. **Tauri + React es un sweet spot.** El bundle es chico, el hot reload funciona, y el backend en Rust tiene performance nativo sin la complejidad de una app SwiftUI completa.
+4. **Tauri + React es un sweet spot.** El bundle es chico, el hot reload funcióna, y el backend en Rust tiene performance nativo sin la complejidad de una app SwiftUI completa.
 
 ---
 
-*Anterior: [Capitulo 4 — Inyeccion sin recompilar](04-inyeccion-sin-recompilar.md) | Siguiente: [Capitulo 6 — Alternativas](06-alternativas.md)*
+*Anterior: [Capítulo 4 — Inyección sin recompilar](04-inyeccion-sin-recompilar.md) | Siguiente: [Capítulo 6 — Alternativas](06-alternativas.md)*

--- a/docs/libro/06-alternativas.md
+++ b/docs/libro/06-alternativas.md
@@ -1,20 +1,20 @@
-# Capitulo 6 — Alternativas
+# Capítulo 6 — Alternativas
 
-## Por que listamos a la competencia
+## Por qué listamos a la competencia
 
-En 2022, Brandon Williams y Stephen Celis de [Point-Free](https://www.pointfree.co) hicieron algo poco comun: publicaron una pagina en su sitio listando cada competidor de su libreria de Composable Architecture, explicando que hacia bien cada uno y en que se diferenciaban. No fue un truco de marketing. Fue un acto de respeto — hacia los usuarios que merecen tomar decisiones informadas, y hacia los equipos que construyeron esas herramientas.
+En 2022, Brandon Williams y Stephen Celis de [Point-Free](https://www.pointfree.co) hicieron algo poco común: publicaron una página en su sitio listando cada competidor de su libreria de Composable Architecture, explicando que hacia bien cada uno y en que se diferenciaban. No fue un truco de marketing. Fue un acto de respeto — hacia los usuarios que merecen tomar decisiones informadas, y hacia los equipos que construyeron esas herramientas.
 
-Este capitulo sigue esa filosofia.
+Este capítulo sigue esa filosofia.
 
-AutoPilot existe en un ecosistema con herramientas maduras, bien financiadas, con comunidades activas. Varias de ellas resuelven problemas que AutoPilot aun no toca. Otras llevan anos de ventaja en integraciones, documentacion y soporte. Si una de ellas resuelve tu problema, usala.
+AutoPilot existe en un ecosistema con herramientas maduras, bien financiadas, con comúnidades activas. Varias de ellas resuelven problemas que AutoPilot aun no toca. Otras llevan anos de ventaja en integraciónes, documentación y soporte. Si una de ellas resuelve tu problema, usala.
 
-Lo que ofrecemos aqui es un analisis tecnico honesto: como funciona cada herramienta por dentro, que decisiones arquitectonicas tomaron, donde brillan y donde tienen fricciones. Con esa informacion, puedes decidir que camino tomar.
+Lo que ofrecemos aqui es un análisis técnico honesto: cómo funcióna cada herramienta por dentro, que decisiones arquitectonicas tomaron, donde brillan y donde tienen fricciones. Con esa información, puedes decidir que camino tomar.
 
 ---
 
 ## El landscape
 
-La automatizacion iOS se puede dividir en cuatro capas, segun donde vive la herramienta:
+La automatización iOS se puede dividir en cuatro capas, segun donde vive la herramienta:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -35,7 +35,7 @@ La automatizacion iOS se puede dividir en cuatro capas, segun donde vive la herr
 
 La mayoria de las herramientas opera en las capas 3 y 4, construyendo sobre XCUITest como base. AutoPilot y AXe son las unicas que operan directamente en la capa 1.
 
-Esta decision tiene consecuencias profundas. Operar en capas altas da acceso a ecosistemas maduros, documentacion abundante y soporte comunitario. Operar en la capa 1 da control total, menos dependencias, pero tambien mas responsabilidad sobre cada detalle.
+Esta decision tiene consecuencias profundas. Operar en capas altas da acceso a ecosistemas maduros, documentación abundante y soporte comúnitario. Operar en la capa 1 da control total, menos dependencias, pero también más responsabilidad sobre cada detalle.
 
 ---
 
@@ -45,11 +45,11 @@ Esta decision tiene consecuencias profundas. Operar en capas altas da acceso a e
 **Lenguaje:** Swift / Objective-C
 **Desde:** 2015 (Xcode 7)
 
-### Como funciona
+### Cómo funcióna
 
 XCUITest es el framework de Apple para UI testing. Requiere un test target dentro de un proyecto de Xcode, que se compila junto con la app y se ejecuta a traves de un test runner. Internamente, XCUITest usa APIs privadas de accesibilidad de iOS — no de macOS — para interactuar con la UI.
 
-El flujo es: Xcode compila el test bundle, lo instala en el simulador (o dispositivo), lanza un proceso `XCTRunner` que coordina la ejecucion, y cada `XCUIElement.tap()` se traduce a un evento de toque sintetico dentro de iOS.
+El flujo es: Xcode compila el test bundle, lo instala en el simulador (o dispositivo), lanza un proceso `XCTRunner` que coordina la ejecución, y cada `XCUIElement.tap()` se traduce a un evento de toque sintetico dentro de iOS.
 
 ```swift
 // XCUITest clasico
@@ -63,24 +63,24 @@ func testLogin() {
 }
 ```
 
-### Que hace bien
+### Qué hace bien
 
 - Es el framework oficial de Apple. Cualquier comportamiento de accesibilidad que Apple soporte, XCUITest lo ve.
-- Integracion nativa con Xcode: breakpoints, grabacion de tests, reportes.
+- Integración nativa con Xcode: breakpoints, grabacion de tests, reportes.
 - No necesita dependencias externas si ya tienes Xcode.
-- Es la base sobre la que funcionan Appium, Maestro y WebDriverAgent.
+- Es la base sobre la que funciónan Appium, Maestro y WebDriverAgent.
 
-### Limitaciones
+### Limitaciónes
 
 - Requiere un test target compilado con el proyecto. No puedes automatizar una app de la que solo tienes el `.app` bundle.
-- Cada ejecucion implica un ciclo de compilacion. En CI, esto agrega minutos.
+- Cada ejecución implica un ciclo de compilación. En CI, esto agrega minutos.
 - No hay forma nativa de correr scripts desde la terminal sin `xcodebuild test`.
-- No tiene camera mock, no tiene inyeccion de sensores, no tiene control de red.
+- No tiene camera mock, no tiene inyección de sensores, no tiene control de red.
 - El matching de elementos tiene quirks: botones en SwiftUI `NavigationBar` reportan `AXChildren = [0]`, placeholders viven en atributos inconsistentes entre versiones.
 
 ### Diferencia clave con AutoPilot
 
-XCUITest opera *dentro* de iOS. AutoPilot opera *desde fuera*, desde macOS. XCUITest necesita compilar un test target; AutoPilot necesita solo el PID del Simulador. XCUITest es un framework de testing; AutoPilot es una herramienta de automatizacion — no asume que estas escribiendo tests.
+XCUITest opera *dentro* de iOS. AutoPilot opera *desde fuera*, desde macOS. XCUITest necesita compilar un test target; AutoPilot necesita solo el PID del Simulador. XCUITest es un framework de testing; AutoPilot es una herramienta de automatización — no asume que estas escribiendo tests.
 
 ---
 
@@ -91,9 +91,9 @@ XCUITest opera *dentro* de iOS. AutoPilot opera *desde fuera*, desde macOS. XCUI
 **Protocolo:** WebDriver W3C
 **Desde:** 2013
 
-### Como funciona
+### Cómo funcióna
 
-Appium es un servidor HTTP que implementa el protocolo WebDriver W3C — el mismo estandar que usan Selenium y los navegadores. Para iOS, Appium usa un driver llamado `appium-xcuitest-driver` que internamente despliega **WebDriverAgent** (WDA) en el simulador o dispositivo. WDA es un proceso que corre dentro del entorno iOS, escucha en un puerto HTTP, recibe comandos JSON, y los traduce a llamadas de XCUITest.
+Appium es un servidor HTTP que implementa el protocolo WebDriver W3C — el mismo estándar que usan Selenium y los navegadores. Para iOS, Appium usa un driver llamado `appium-xcuitest-driver` que internamente despliega **WebDriverAgent** (WDA) en el simulador o dispositivo. WDA es un proceso que corre dentro del entorno iOS, escucha en un puerto HTTP, recibe comandos JSON, y los traduce a llamadas de XCUITest.
 
 ```
 Cliente (Python/Java)
@@ -108,27 +108,27 @@ WDA (dentro del Simulador, puerto 8100)
 App iOS
 ```
 
-El setup tipico involucra: Node.js + npm, `appium` CLI global, el driver de iOS (`appium driver install xcuitest`), opcionalmente Java para Android, y un cliente en el lenguaje de tu eleccion.
+El setup tipico involucra: Node.js + npm, `appium` CLI global, el driver de iOS (`appium driver install xcuitest`), opciónalmente Java para Android, y un cliente en el lenguaje de tu eleccion.
 
-### Que hace bien
+### Qué hace bien
 
-- Es el estandar de facto en enterprise. Si llegas a una empresa grande, probablemente ya tienen Appium.
+- Es el estándar de facto en enterprise. Si llegas a una empresa grande, probablemente ya tienen Appium.
 - Soporta iOS, Android, Windows, Mac, y custom drivers. Un equipo puede unificar todo bajo un protocolo.
-- La comunidad es enorme: miles de plugins, integraciones con Sauce Labs, BrowserStack, LambdaTest.
+- La comúnidad es enorme: miles de plugins, integraciónes con Sauce Labs, BrowserStack, LambdaTest.
 - Los clientes multi-lenguaje permiten que equipos de QA usen Python o Java, no Swift.
 - El modelo de sesiones permite correr multiples tests en paralelo con diferentes capabilities.
 
-### Limitaciones
+### Limitaciónes
 
-- El stack completo requiere 3-5 procesos corriendo simultaneamente: tu test, el servidor Appium, WDA, el simulador, y opcionalmente un proxy.
+- El stack completo requiere 3-5 procesos corriendo simultaneamente: tu test, el servidor Appium, WDA, el simulador, y opciónalmente un proxy.
 - El overhead de HTTP entre cada capa agrega latencia. Un tap que toma 89ms nativamente puede tomar 200-500ms a traves de Appium.
 - WDA necesita re-compilarse cuando cambias de Xcode. Es una fuente constante de errores en CI: `Unable to launch WebDriverAgent`, `Session creation failed`.
-- No tiene camera mock nativo. La solucion es usar servicios cloud (BrowserStack tiene `cameraMock` capability) o mockear a nivel de app.
-- El debugging cuando algo falla es complejo: ¿fallo el cliente? ¿el servidor? ¿WDA? ¿XCUITest? La cadena es larga.
+- No tiene camera mock nativo. La solución es usar servicios cloud (BrowserStack tiene `cameraMock` capability) o mockear a nivel de app.
+- El debugging cuando algo falla es complejo: ¿falló el cliente? ¿el servidor? ¿WDA? ¿XCUITest? La cadena es larga.
 
 ### Diferencia clave con AutoPilot
 
-Appium es una capa de abstraccion sobre XCUITest. AutoPilot elimina esa cadena por completo: no hay servidor, no hay protocolo HTTP, no hay WDA. El CLI habla directamente con las APIs de accesibilidad de macOS. Appium es la mejor opcion si necesitas multi-plataforma con un equipo de QA existente. AutoPilot esta disenado para ingenieros iOS que quieren control directo.
+Appium es una capa de abstraccion sobre XCUITest. AutoPilot elimina esa cadena por completo: no hay servidor, no hay protocolo HTTP, no hay WDA. El CLI habla directamente con las APIs de accesibilidad de macOS. Appium es la mejor opción si necesitas multi-plataforma con un equipo de QA existente. AutoPilot está diseñado para ingenieros iOS que quieren control directo.
 
 ---
 
@@ -138,7 +138,7 @@ Appium es una capa de abstraccion sobre XCUITest. AutoPilot elimina esa cadena p
 **Lenguaje:** Kotlin / JVM
 **Desde:** 2022
 
-### Como funciona
+### Cómo funcióna
 
 Maestro es una herramienta CLI que ejecuta flujos definidos en YAML. Su propuesta es simple: defines pasos como `tapOn`, `assertVisible`, `inputText`, y Maestro se encarga del resto. Se instala con un `curl | bash`.
 
@@ -147,7 +147,7 @@ Por debajo, Maestro lanza un **XCUITest "zombie"** — un test target que nunca 
 1. Maestro CLI (Kotlin/JVM) lee el YAML.
 2. Envia comandos HTTP al servidor dentro del XCUITest runner.
 3. El runner ejecuta acciones via XCUITest APIs.
-4. El matching de elementos (por texto, id, index) lo hace Maestro en Kotlin, no XCUITest. El runner solo envia el arbol de accesibilidad completo.
+4. El matching de elementos (por texto, id, index) lo hace Maestro en Kotlin, no XCUITest. El runner solo envia el árbol de accesibilidad completo.
 
 ```yaml
 # flow.yaml
@@ -162,25 +162,25 @@ appId: com.example.app
 
 Requiere Java/JVM instalado. El binario de instalacion descarga una JVM embebida si no la encuentra.
 
-### Que hace bien
+### Qué hace bien
 
-- La experiencia de primer uso es excelente. `curl | bash`, escribe un YAML, corre `maestro test flow.yaml`. Dos minutos y funciona.
-- Los GIF demos en el README son convincentes — ves la automatizacion corriendo en tiempo real.
+- La experiencia de primer uso es excelente. `curl | bash`, escribe un YAML, corre `maestro test flow.yaml`. Dos minutos y funcióna.
+- Los GIF demos en el README son convincentes — ves la automatización corriendo en tiempo real.
 - Maestro Cloud ofrece CI/CD sin configurar infraestructura.
 - El YAML es accesible para QA engineers que no programan en Swift o Kotlin.
 - El matching por texto es inteligente: busca en labels, placeholders, values, hints.
 
-### Limitaciones
+### Limitaciónes
 
-- El YAML, cuando los flujos crecen, se vuelve limitante. No hay variables con logica, no hay funciones, no hay composicion real. Hay workarounds (`runFlow`, variables de entorno), pero no es un lenguaje.
+- El YAML, cuando los flujos crecen, se vuelve limitante. No hay variables con logica, no hay funciónes, no hay composicion real. Hay workarounds (`runFlow`, variables de entorno), pero no es un lenguaje.
 - Requiere JVM. En CI, esto son ~200MB adicionales. En maquinas de desarrolladores, es otra runtime que mantener.
-- Depende de XCUITest por debajo. Los mismos quirks del arbol de accesibilidad aplican.
+- Depende de XCUITest por debajo. Los mismos quirks del árbol de accesibilidad aplican.
 - No tiene camera mock. Si tu app abre `AVCaptureSession`, Maestro no puede interceptar eso.
 - El servidor HTTP interno significa que hay un proceso extra corriendo en el simulador. En simuladores con poca memoria, esto puede causar inestabilidad.
 
 ### Diferencia clave con AutoPilot
 
-Maestro optimiza la experiencia del usuario sobre YAML. AutoPilot optimiza la transparencia — puedes ver exactamente que API se llama en cada paso. Maestro necesita JVM + XCUITest; AutoPilot es un binario Swift de ~2MB sin dependencias. AutoPilot tiene camera mock via DYLD_INSERT_LIBRARIES; Maestro no puede interceptar la camara. Si tu equipo es QA-first y no necesita camara, Maestro es una opcion solida.
+Maestro optimiza la experiencia del usuario sobre YAML. AutoPilot optimiza la transparencia — puedes ver exactamente que API se llama en cada paso. Maestro necesita JVM + XCUITest; AutoPilot es un binario Swift de ~2MB sin dependencias. AutoPilot tiene camera mock via DYLD_INSERT_LIBRARIES; Maestro no puede interceptar la cámara. Si tu equipo es QA-first y no necesita cámara, Maestro es una opción solida.
 
 ---
 
@@ -190,11 +190,11 @@ Maestro optimiza la experiencia del usuario sobre YAML. AutoPilot optimiza la tr
 **Lenguaje:** JavaScript / Objective-C
 **Desde:** 2017
 
-### Como funciona
+### Cómo funcióna
 
-Detox es un framework de testing "gray box" creado por Wix, disenado especificamente para React Native. "Gray box" significa que Detox tiene acceso tanto a la interfaz (como un usuario) como a los internos de la app (como un debugger).
+Detox es un framework de testing "gray box" creado por Wix, diseñado específicamente para React Native. "Gray box" significa que Detox tiene acceso tanto a la interfaz (como un usuario) como a los internos de la app (como un debugger).
 
-En iOS, Detox usa **EarlGrey 2.0** como motor de interaccion con la UI. El componente clave es la sincronizacion: Detox espera a que el JavaScript event loop de React Native, las animaciones nativas, las peticiones de red y las transiciones de navegacion terminen *antes* de ejecutar el siguiente paso. Esto elimina la mayoria de los `waitFor` manuales.
+En iOS, Detox usa **EarlGrey 2.0** como motor de interacción con la UI. El componente clave es la sincronización: Detox espera a que el JavaScript event loop de React Native, las animaciones nativas, las peticiones de red y las transiciones de navegación terminen *antes* de ejecutar el siguiente paso. Esto elimina la mayoria de los `waitFor` manuales.
 
 ```javascript
 // Detox test
@@ -208,24 +208,24 @@ describe('Login', () => {
 });
 ```
 
-### Que hace bien
+### Qué hace bien
 
-- La sincronizacion automatica es su killer feature. En React Native, los flaky tests suelen venir de timing — Detox resuelve esto a nivel de framework.
+- La sincronización automática es su killer feature. En React Native, los flaky tests suelen venir de timing — Detox resuelve esto a nivel de framework.
 - La API es ergonomica y familiar para desarrolladores JavaScript.
-- Wix lo usa internamente en produccion con apps de millones de usuarios. No es un proyecto de fin de semana.
+- Wix lo usa internamente en producción con apps de millones de usuarios. No es un proyecto de fin de semana.
 - El modelo gray box permite verificar estado interno de la app, no solo lo visible en pantalla.
 
-### Limitaciones
+### Limitaciónes
 
-- Solo funciona con React Native. Si tu app es Swift nativo o SwiftUI, Detox no aplica.
+- Solo funcióna con React Native. Si tu app es Swift nativo o SwiftUI, Detox no aplica.
 - Requiere Node.js, npm, y un build especial de la app con el server de Detox embebido.
-- EarlGrey 2.0, su motor interno, depende de XCUITest. Heredas sus limitaciones.
-- Camera mock es posible solo a traves de modulos React Native que wrappean la camara — no es una solucion generica.
-- La configuracion inicial (`detox build`, `detox test`, archivos de configuracion por plataforma) tiene curva de aprendizaje.
+- EarlGrey 2.0, su motor interno, depende de XCUITest. Heredas sus limitaciónes.
+- Camera mock es posible solo a traves de modulos React Native que wrappean la cámara — no es una solución generica.
+- La configuración inicial (`detox build`, `detox test`, archivos de configuración por plataforma) tiene curva de aprendizaje.
 
 ### Diferencia clave con AutoPilot
 
-Detox resuelve un problema especifico (testing de React Native) muy bien. AutoPilot resuelve un problema diferente (automatizacion de cualquier app iOS desde la terminal). No compiten directamente. Si tu stack es React Native, Detox es probablemente la mejor opcion para testing de UI.
+Detox resuelve un problema específico (testing de React Native) muy bien. AutoPilot resuelve un problema diferente (automatización de cualquier app iOS desde la terminal). No compiten directamente. Si tu stack es React Native, Detox es probablemente la mejor opción para testing de UI.
 
 ---
 
@@ -235,33 +235,33 @@ Detox resuelve un problema especifico (testing de React Native) muy bien. AutoPi
 **Lenguaje:** Swift
 **Desde:** 2025
 
-### Como funciona
+### Cómo funcióna
 
-AXe es el competidor mas directo de AutoPilot. Comparte la misma filosofia: binario unico, Swift puro, CLI, sin XCUITest, sin servidor. Se instala via Homebrew (`brew install axe`).
+AXe es el competidor más directo de AutoPilot. Comparte la misma filosofia: binario único, Swift puro, CLI, sin XCUITest, sin servidor. Se instala via Homebrew (`brew install axe`).
 
-La diferencia tecnica fundamental esta en *que* APIs usa. AXe utiliza **APIs privadas de accesibilidad de Apple** — funciones que no estan en la documentacion publica, que Apple no garantiza que se mantengan entre versiones. Estas APIs dan acceso mas directo a elementos dentro del simulador, pero con un riesgo: pueden romperse en cualquier actualizacion de macOS o Xcode sin previo aviso.
+La diferencia técnica fundamental esta en *que* APIs usa. AXe utiliza **APIs privadas de accesibilidad de Apple** — funciónes que no estan en la documentación publica, que Apple no garantiza que se mantengan entre versiones. Estas APIs dan acceso más directo a elementos dentro del simulador, pero con un riesgo: pueden romperse en cualquier actualizacion de macOS o Xcode sin previo aviso.
 
-AutoPilot usa **APIs publicas de macOS** (`AXUIElement`, `AXUIElementCopyAttributeValue`, `AXUIElementPerformAction`) — las mismas que usan lectores de pantalla y herramientas de accesibilidad certificadas por Apple. Son estables, documentadas, y parte del contrato publico del sistema operativo.
+AutoPilot usa **APIs públicas de macOS** (`AXUIElement`, `AXUIElementCopyAttributeValue`, `AXUIElementPerformAction`) — las mismas que usan lectores de pantalla y herramientas de accesibilidad certificadas por Apple. Son estables, documentadas, y parte del contrato publico del sistema operativo.
 
-### Que hace bien
+### Qué hace bien
 
 - La experiencia de instalacion es excelente: `brew install axe` y listo.
-- Es rapido. Un binario Swift nativo sin overhead de runtime.
-- El crecimiento rapido (1.7K stars en meses) valida que hay un mercado real para herramientas de automatizacion iOS ligeras.
-- Demuestra que el enfoque de "binario unico sin XCUITest" es viable.
+- Es rápido. Un binario Swift nativo sin overhead de runtime.
+- El crecimiento rápido (1.7K stars en meses) valida que hay un mercado real para herramientas de automatización iOS ligeras.
+- Demuestra que el enfoque de "binario único sin XCUITest" es viable.
 
-### Limitaciones
+### Limitaciónes
 
-- Las APIs privadas son fragiles. Cada major release de macOS o Xcode puede romper funcionalidad sin advertencia. El equipo de AXe tiene que hacer ingenieria inversa despues de cada actualizacion.
+- Las APIs privadas son frágiles. Cada major release de macOS o Xcode puede romper funciónalidad sin advertencia. El equipo de AXe tiene que hacer ingeniería inversa después de cada actualizacion.
 - No tiene camera mock.
 - Al depender de APIs privadas, no puede distribuirse en contextos donde Apple audita el uso de APIs (como Mac App Store o entornos enterprise con politicas de compliance).
-- La documentacion esta principalmente en ingles.
+- La documentación esta principalmente en ingles.
 
 ### Diferencia clave con AutoPilot
 
-AXe y AutoPilot ven el mismo problema desde angulos opuestos. AXe apuesta por APIs privadas: mas poder inmediato, mas riesgo a largo plazo. AutoPilot apuesta por APIs publicas: mas trabajo de integracion, pero estabilidad garantizada por Apple. Ademas, AutoPilot ofrece camera mock via inyeccion de dylib — algo que AXe no tiene y que ningun otro competidor implementa.
+AXe y AutoPilot ven el mismo problema desde angulos opuestos. AXe apuesta por APIs privadas: más poder inmediato, más riesgo a largo plazo. AutoPilot apuesta por APIs públicas: más trabajo de integración, pero estabilidad garantizada por Apple. Además, AutoPilot ofrece camera mock via inyección de dylib — algo que AXe no tiene y que ningún otro competidor implementa.
 
-La existencia de AXe es, para nosotros, una validacion. Dos equipos independientes llegaron a la misma conclusion: la automatizacion iOS debe ser un binario nativo que hable AX, no un wrapper sobre XCUITest.
+La existencia de AXe es, para nosotros, una validacion. Dos equipos independientes llegaron a la misma conclusion: la automatización iOS debe ser un binario nativo que hable AX, no un wrapper sobre XCUITest.
 
 ---
 
@@ -272,38 +272,38 @@ La existencia de AXe es, para nosotros, una validacion. Dos equipos independient
 **Creador:** Meta (Facebook)
 **Desde:** 2019
 
-### Como funciona
+### Cómo funcióna
 
-idb (iOS Development Bridge, un guino a `adb` de Android) es la herramienta interna de Meta para interactuar con simuladores y dispositivos iOS. Tiene dos componentes: un **companion** escrito en Objective-C++ que corre en la Mac y linkea directamente contra frameworks privados de Apple (`CoreSimulator.framework`, `SimulatorKit.framework`), y un **cliente** en Python que se comunica via gRPC.
+idb (iOS Development Bridge, un guino a `adb` de Android) es la herramienta interna de Meta para interactuar con simuladores y dispositivos iOS. Tiene dos componentes: un **companion** escrito en Objective-C++ que corre en la Mac y linkea directamente contra frameworks privados de Apple (`CoreSimulator.framework`, `SimulatorKit.framework`), y un **cliente** en Python que se comúnica via gRPC.
 
-El companion puede: instalar apps, lanzarlas, tomar screenshots, ejecutar `xctest`, interactuar con el pasteboard, obtener logs, y — crucialmente — hacer fetching del arbol de accesibilidad.
+El companion puede: instalar apps, lanzarlas, tomar screenshots, ejecutar `xctest`, interactuar con el pasteboard, obtener logs, y — crucialmente — hacer fetching del árbol de accesibilidad.
 
 ```bash
 # idb en accion
 idb launch com.example.app
-idb ui describe-all        # arbol de accesibilidad
+idb ui describe-all        # árbol de accesibilidad
 idb ui tap 150 300         # tap por coordenadas
 idb ui type "hello"        # typing
 ```
 
-### Que hace bien
+### Qué hace bien
 
 - Es la herramienta que Meta usa internamente para miles de tests diarios. Esta probada a escala.
 - El companion tiene acceso profundo al simulador: puede manipular permisos, pasteboard, localizacion.
-- El accessibility fetching es rapido y completo.
+- El accessibility fetching es rápido y completo.
 - El modelo companion + cliente permite correr el companion en una Mac remota y controlarlo desde cualquier maquina.
 
-### Limitaciones
+### Limitaciónes
 
 - Requiere Python para el cliente. En entornos iOS-only, esto es una dependencia extra.
-- Linkea contra frameworks privados de Apple. Al igual que AXe, cada actualizacion de Xcode puede romper la compilacion.
-- El tap es por coordenadas, no por label. Para automatizacion por elementos, necesitas combinar `describe-all` con parsing propio.
+- Linkea contra frameworks privados de Apple. Al igual que AXe, cada actualizacion de Xcode puede romper la compilación.
+- El tap es por coordenadas, no por label. Para automatización por elementos, necesitas combinar `describe-all` con parsing propio.
 - No tiene camera mock.
 - El proyecto ha tenido periodos de baja actividad — el riesgo de cualquier herramienta interna open-sourced.
 
 ### Diferencia clave con AutoPilot
 
-idb es una navaja suiza para el simulador: puede hacer muchas cosas, pero no esta disenada como herramienta de automatizacion de UI. Su tap es por coordenadas; AutoPilot tapa por label. Su cliente es Python; AutoPilot es un binario autocontenido. Ambos evitan XCUITest, pero por caminos diferentes: idb linkea frameworks privados, AutoPilot usa APIs publicas de macOS.
+idb es una navaja suiza para el simulador: puede hacer muchas cosas, pero no esta disenada como herramienta de automatización de UI. Su tap es por coordenadas; AutoPilot tapa por label. Su cliente es Python; AutoPilot es un binario autocontenido. Ambos evitan XCUITest, pero por caminos diferentes: idb linkea frameworks privados, AutoPilot usa APIs públicas de macOS.
 
 ---
 
@@ -314,11 +314,11 @@ idb es una navaja suiza para el simulador: puede hacer muchas cosas, pero no est
 **Creador:** Google
 **Desde:** 2016
 
-### Como funciona
+### Cómo funcióna
 
-EarlGrey es un framework de testing "gray box" de Google para iOS nativo. Originalmente (1.0) funcionaba como un framework que se embedia directamente en la app, con acceso al mismo proceso — podia esperar animaciones, network calls, y dispatch queues.
+EarlGrey es un framework de testing "gray box" de Google para iOS nativo. Originalmente (1.0) funciónaba como un framework que se embedia directamente en la app, con acceso al mismo proceso — podia esperar animaciones, network calls, y dispatch queues.
 
-EarlGrey 2.0 cambio el modelo: ahora se integra *con* XCUITest en lugar de reemplazarlo. El test corre en el proceso de XCUITest, pero un componente embebido en la app (via un framework adicional) provee la sincronizacion.
+EarlGrey 2.0 cambio el modelo: ahora se integra *con* XCUITest en lugar de reemplazarlo. El test corre en el proceso de XCUITest, pero un componente embebido en la app (via un framework adicional) provee la sincronización.
 
 ```objc
 // EarlGrey 2.0
@@ -332,24 +332,24 @@ EarlGrey 2.0 cambio el modelo: ahora se integra *con* XCUITest en lugar de reemp
 }
 ```
 
-### Que hace bien
+### Qué hace bien
 
-- La sincronizacion de EarlGrey 1.0 era revolucionaria para su epoca. Eliminaba waits arbitrarios.
+- La sincronización de EarlGrey 1.0 era revolucionaria para su epoca. Eliminaba waits arbitrarios.
 - La API de matchers es expresiva y composable.
 - Google lo usa(ba) internamente para apps como YouTube, Google Maps, Gmail.
 
-### Limitaciones
+### Limitaciónes
 
 - EarlGrey 1.0 esta deprecado.
 - EarlGrey 2.0 depende completamente de XCUITest. Perdio la ventaja principal del modelo gray box original.
 - El proyecto tiene actividad minima. Los issues se acumulan, los PRs tardan meses en revisarse.
-- La configuracion de EarlGrey 2.0 es compleja: necesitas un test target, el framework de EarlGrey en la app, y el componente en el test target.
+- La configuración de EarlGrey 2.0 es compleja: necesitas un test target, el framework de EarlGrey en la app, y el componente en el test target.
 - No tiene camera mock.
-- La comunidad ha migrado mayoritariamente a XCUITest nativo o a Maestro.
+- La comúnidad ha migrado mayoritariamente a XCUITest nativo o a Maestro.
 
 ### Diferencia clave con AutoPilot
 
-EarlGrey representa un enfoque que tuvo su momento pero esta en declive. Su contribucion historica — sincronizacion automatica — fue adoptada por Detox y, parcialmente, por XCUITest. AutoPilot no compite con EarlGrey directamente; mencionamos la herramienta para dar contexto historico y porque Detox la usa internamente.
+EarlGrey representa un enfoque que tuvo su momento pero esta en declive. Su contribucion historica — sincronización automática — fue adoptada por Detox y, parcialmente, por XCUITest. AutoPilot no compite con EarlGrey directamente; mencionamos la herramienta para dar contexto historico y porque Detox la usa internamente.
 
 ---
 
@@ -361,35 +361,35 @@ EarlGrey representa un enfoque que tuvo su momento pero esta en declive. Su cont
 | **Dependencias runtime** | Ninguna | JVM | Node + drivers | Xcode | Node | Ninguna | Python |
 | **Instalacion** | Binario | curl + JVM | npm + plugins | Ya incluido | npm | brew | pip + build |
 | **Usa XCUITest** | No | Si (zombie) | Si (WDA) | Es XCUITest | Si (EarlGrey) | No | Parcial |
-| **APIs de acceso** | AX publicas | XCUITest HTTP | WebDriver W3C | Privadas iOS | EarlGrey 2.0 | AX privadas | Frameworks privados |
+| **APIs de acceso** | AX públicas | XCUITest HTTP | WebDriver W3C | Privadas iOS | EarlGrey 2.0 | AX privadas | Frameworks privados |
 | **Camera mock** | Si (dylib) | No | No* | No | No** | No | No |
 | **Tap por label** | Si | Si | Si | Si | Si | Si | No (coordenadas) |
 | **Multi-plataforma** | Solo iOS | iOS + Android | iOS + Android + Web | Solo iOS | Solo RN | Solo iOS | Solo iOS |
-| **Formato de scripts** | .auto | YAML | Codigo (multi-lang) | Swift/ObjC | JavaScript | CLI args | CLI args |
+| **Formato de scripts** | .auto | YAML | Código (multi-lang) | Swift/ObjC | JavaScript | CLI args | CLI args |
 | **Stars** | — | 13.4K | 21.4K | — | 11.9K | 1.7K | 5K |
 
 \* Appium soporta camera mock a traves de servicios cloud (BrowserStack, Sauce Labs), no nativamente.
-\** Detox puede mockear camara a traves de modulos React Native, no a nivel de sistema.
+\** Detox puede mockear cámara a traves de modulos React Native, no a nivel de sistema.
 
 ---
 
-## Por que elegimos otro camino
+## Por qué elegimos otro camino
 
 No elegimos construir AutoPilot porque las alternativas sean malas. Las elegimos porque resuelven un problema diferente al que nos interesa.
 
 **El stack convencional** (Appium, Maestro, XCUITest) asume que quieres escribir *tests*. Asume un runner, un framework de assertions, un reporte de resultados. La herramienta vive en el mundo de QA.
 
-**AutoPilot asume que quieres *controlar* el simulador.** Quieres hacer tap, leer la pantalla, inyectar una imagen como camara, tomar un screenshot — desde la terminal, sin compilar nada, sin levantar servidores, sin instalar runtimes. Que despues uses eso para testing, para demos, para CI, o para explorar una app que no compilaste tu, es tu decision.
+**AutoPilot asume que quieres *controlar* el simulador.** Quieres hacer tap, leer la pantalla, inyectar una imagen como cámara, tomar un screenshot — desde la terminal, sin compilar nada, sin levantar servidores, sin instalar runtimes. Qué después uses eso para testing, para demos, para CI, o para explorar una app que no compilaste tu, es tu decision.
 
 Las decisiones que se derivan de esa premisa son:
 
-1. **Swift puro, binario unico.** Si la herramienta es para ingenieros iOS, debe hablar su idioma y no pedirles instalar Node, Java o Python.
+1. **Swift puro, binario único.** Si la herramienta es para ingenieros iOS, debe hablar su idioma y no pedirles instalar Node, Java o Python.
 
-2. **APIs publicas de macOS.** Las APIs privadas dan mas poder hoy, pero las publicas dan estabilidad manana. Preferimos construir sobre un contrato que Apple mantiene para millones de usuarios con discapacidad.
+2. **APIs públicas de macOS.** Las APIs privadas dan más poder hoy, pero las públicas dan estabilidad mañana. Preferimos construir sobre un contrato que Apple mantiene para millones de usuarios con discapacidad.
 
-3. **Camera mock via DYLD_INSERT_LIBRARIES.** Nadie mas hace esto. No porque sea imposible, sino porque requiere un conocimiento profundo del ObjC runtime, ARM64 PAC, y el pipeline de AVFoundation. Es nuestra contribucion unica al espacio.
+3. **Camera mock via DYLD_INSERT_LIBRARIES.** Nadie más hace esto. No porque sea imposible, sino porque requiere un conocimiento profundo del ObjC runtime, ARM64 PAC, y el pipeline de AVFoundation. Es nuestra contribucion única al espacio.
 
-4. **Scripts .auto en lugar de YAML o codigo.** Un formato simple, legible, que se puede generar, parsear y depurar sin un IDE.
+4. **Scripts .auto en lugar de YAML o código.** Un formato simple, legible, que se puede generar, parsear y depurar sin un IDE.
 
 ### Cuando no usar AutoPilot
 
@@ -397,23 +397,23 @@ Seamos directos:
 
 - **Si necesitas iOS + Android con un solo framework**, usa Maestro o Appium. AutoPilot es solo iOS (por ahora).
 - **Si tu equipo es de QA y no programa en Swift**, usa Maestro (YAML) o Appium (Python/Java).
-- **Si necesitas el ecosistema enterprise** (Sauce Labs, BrowserStack, reportes HTML, integraciones con Jira), usa Appium.
-- **Si tu app es React Native**, Detox resuelve el problema de sincronizacion mejor que cualquier herramienta generica.
-- **Si solo necesitas tests basicos y ya estas en Xcode**, XCUITest funciona sin instalar nada adicional.
+- **Si necesitas el ecosistema enterprise** (Sauce Labs, BrowserStack, reportes HTML, integraciónes con Jira), usa Appium.
+- **Si tu app es React Native**, Detox resuelve el problema de sincronización mejor que cualquier herramienta generica.
+- **Si solo necesitas tests básicos y ya estas en Xcode**, XCUITest funcióna sin instalar nada adicional.
 
 ### Cuando AutoPilot tiene sentido
 
 - Cuando quieres automatizar sin compilar un test target.
 - Cuando necesitas camera mock en el simulador y no quieres pagar $400/mes por un servicio cloud.
-- Cuando quieres un binario de 2MB que funciona con `./auto tap "Login"` y nada mas.
-- Cuando quieres entender *exactamente* que hace tu herramienta de automatizacion, linea por linea.
+- Cuando quieres un binario de 2MB que funcióna con `./auto tap "Login"` y nada mas.
+- Cuando quieres entender *exactamente* que hace tu herramienta de automatización, línea por línea.
 - Cuando valoras la independencia de runtimes externos.
 
-El ecosistema de automatizacion iOS necesita diversidad de enfoques. XCUITest es la base solida que Apple mantiene. Appium es el estandar enterprise probado a escala. Maestro es la experiencia de usuario mas pulida. AXe valida que el enfoque nativo sin XCUITest es viable. AutoPilot aporta APIs publicas, camera mock, y transparencia total.
+El ecosistema de automatización iOS necesita diversidad de enfoques. XCUITest es la base solida que Apple mantiene. Appium es el estándar enterprise probado a escala. Maestro es la experiencia de usuario más pulida. AXe valida que el enfoque nativo sin XCUITest es viable. AutoPilot aporta APIs públicas, camera mock, y transparencia total.
 
 Cada herramienta eligio sus trade-offs. Nosotros elegimos los nuestros.
 
 ---
 
-*Anterior: [Capitulo 5 — El editor](05-el-editor.md)*
-*Siguiente: [Capitulo 7 — Decisiones](07-decisiones.md)*
+*Anterior: [Capítulo 5 — El editor](05-el-editor.md)*
+*Siguiente: [Capítulo 7 — Decisiones](07-decisiones.md)*

--- a/docs/libro/07-decisiones.md
+++ b/docs/libro/07-decisiones.md
@@ -1,8 +1,8 @@
-# Capitulo 7 — Decisiones
+# Capítulo 7 — Decisiones
 
-Cada proyecto tecnico acumula decisiones que rara vez se documentan. Se toman en una conversacion, en un commit a las 11 de la noche, o despues de tres intentos fallidos. Meses despues, alguien pregunta "¿por que se hizo asi?" y nadie recuerda el contexto.
+Cada proyecto técnico acumula decisiones que rara vez se documentan. Se toman en una conversacion, en un commit a las 11 de la noche, o después de tres intentos fallidos. Meses después, alguien pregunta "¿por qué se hizo así?" y nadie recuerda el contexto.
 
-Este capitulo documenta las decisiones arquitectonicas de AutoPilot en formato ADR (Architecture Decision Record). Cada una incluye el contexto real en el que se tomo, las opciones que evaluamos, lo que elegimos, y las consecuencias — buenas y malas. No hay decisiones perfectas; hay decisiones informadas con tradeoffs explicitos.
+Este capítulo documenta las decisiones arquitectonicas de AutoPilot en formato ADR (Architecture Decision Record). Cada una incluye el contexto real en el que se tomo, las opciones que evaluamos, lo que elegimos, y las consecuencias — buenas y malas. No hay decisiones perfectas; hay decisiones informadas con tradeoffs explícitos.
 
 ---
 
@@ -11,7 +11,7 @@ Este capitulo documenta las decisiones arquitectonicas de AutoPilot en formato A
 | ADR | Titulo | Estado |
 |-----|--------|--------|
 | 1 | Swift puro sin dependencias | Aceptada |
-| 2 | AXUIElement publicas, no APIs privadas | Aceptada |
+| 2 | AXUIElement públicas, no APIs privadas | Aceptada |
 | 3 | Sin XCUITest | Aceptada |
 | 4 | Scripts .auto, no YAML ni JavaScript | Aceptada |
 | 5 | Tauri, no Electron | Aceptada |
@@ -22,11 +22,11 @@ Este capitulo documenta las decisiones arquitectonicas de AutoPilot en formato A
 
 ### ADR 1: Swift puro sin dependencias
 
-**Contexto:** Necesitabamos un CLI para macOS que pudiera leer el arbol de accesibilidad del Simulador, enviar eventos de toque, y controlar `simctl`. La pregunta inicial era simple: ¿en que lenguaje lo escribimos?
+**Contexto:** Necesitabamos un CLI para macOS que pudiera leer el árbol de accesibilidad del Simulador, enviar eventos de toque, y controlar `simctl`. La pregunta inicial era simple: ¿en que lenguaje lo escribimos?
 
-**Opciones:**
+**Opciónes:**
 
-1. **Python** — Rapido de prototipar. Tiene `pyobjc` para acceder a APIs de macOS. Comunidad enorme, miles de librerías CLI. Pero requiere runtime instalado, la interaccion con AXUIElement via `pyobjc` es indirecta y fragil, y distribuir un binario standalone en Python es un dolor (PyInstaller, cx_Freeze, etc.).
+1. **Python** — Rápido de prototipar. Tiene `pyobjc` para acceder a APIs de macOS. Comunidad enorme, miles de librerías CLI. Pero requiere runtime instalado, la interacción con AXUIElement via `pyobjc` es indirecta y frágil, y distribuir un binario standalone en Python es un dolor (PyInstaller, cx_Freeze, etc.).
 
 2. **Go** — Binario estatico, cross-platform, excelente tooling CLI (cobra, viper). Pero no tiene acceso nativo a frameworks de macOS. Llamar a AXUIElement desde Go requiere CGo + bindings manuales en C. Cada API de macOS que necesitas es otro binding que mantener.
 
@@ -37,7 +37,7 @@ Este capitulo documenta las decisiones arquitectonicas de AutoPilot en formato A
 **Decision:** Swift. No por preferencia estetica sino por acceso directo: las APIs que necesitamos son de macOS y Swift las llama sin intermediarios.
 
 ```swift
-// Esto es todo lo que necesitas para leer el arbol de accesibilidad.
+// Esto es todo lo que necesitas para leer el árbol de accesibilidad.
 // Sin import de terceros, sin bindings, sin FFI.
 let app = AXUIElementCreateApplication(pid)
 var value: AnyObject?
@@ -54,36 +54,36 @@ Lo que ganamos:
 
 Lo que perdemos:
 - Solo macOS. Si algun dia queremos Linux o Windows, no sirve.
-- La comunidad de herramientas CLI en Swift es pequena comparada con Go o Python. No hay equivalente a `cobra` o `click`.
-- SPM tiene sus limitaciones (no soporta plugins pre-build de forma ergonomica, los tests de integracion son incomodos).
+- La comúnidad de herramientas CLI en Swift es pequena comparada con Go o Python. No hay equivalente a `cobra` o `click`.
+- SPM tiene sus limitaciónes (no soporta plugins pre-build de forma ergonomica, los tests de integración son incomodos).
 - Los ingenieros que conozcan Go o Python no pueden contribuir sin aprender Swift.
 
 ---
 
-### ADR 2: AXUIElement publicas, no APIs privadas
+### ADR 2: AXUIElement públicas, no APIs privadas
 
-**Contexto:** Para leer la UI del Simulador iOS necesitamos Accessibility APIs de macOS. Hay tres niveles de acceso: las APIs publicas documentadas (`AXUIElement*`), las APIs privadas que Apple usa internamente (como las que usa AXe), y XCUITest que expone su propio arbol.
+**Contexto:** Para leer la UI del Simulador iOS necesitamos Accessibility APIs de macOS. Hay tres niveles de acceso: las APIs públicas documentadas (`AXUIElement*`), las APIs privadas que Apple usa internamente (como las que usa AXe), y XCUITest que expone su propio árbol.
 
-**Opciones:**
+**Opciónes:**
 
-1. **APIs publicas de macOS (AXUIElement)** — Documentadas en `ApplicationServices/HIServices`. Estables entre versiones de macOS. Requieren permiso de Accessibility en TCC. Funcionalidad limitada a lo que Apple expone publicamente.
+1. **APIs públicas de macOS (AXUIElement)** — Documentadas en `ApplicationServices/HIServices`. Estables entre versiones de macOS. Requieren permiso de Accessibility en TCC. Funcionalidad limitada a lo que Apple expone publicamente.
 
-2. **APIs privadas de Apple** — Herramientas como AXe usan frameworks privados (`AccessibilityUIService`, `AXRuntime`) que exponen mas funcionalidad: snapshots completos, jerarquias mas profundas, atributos internos. Pero no estan documentadas, cambian sin aviso entre versiones, y Apple puede bloquearlas en cualquier momento.
+2. **APIs privadas de Apple** — Herramientas como AXe usan frameworks privados (`AccessibilityUIService`, `AXRuntime`) que exponen más funciónalidad: snapshots completos, jerarquías más profundas, atributos internos. Pero no estan documentadas, cambian sin aviso entre versiones, y Apple puede bloquearlas en cualquier momento.
 
-3. **XCUITest** — Tiene su propio mecanismo para leer el arbol de accesibilidad via `XCUIApplication.debugDescription`. Funciona bien dentro de su ecosistema. Pero requiere compilar un test target, lo que contradice nuestra premisa de cero compilacion.
+3. **XCUITest** — Tiene su propio mecanismo para leer el árbol de accesibilidad via `XCUIApplication.debugDescription`. Funciona bien dentro de su ecosistema. Pero requiere compilar un test target, lo que contradice nuestra premisa de cero compilación.
 
-**Decision:** APIs publicas. Usamos exclusivamente `AXUIElementCreateApplication`, `AXUIElementCopyAttributeValue`, `AXUIElementPerformAction` y funciones relacionadas del framework publico de macOS.
+**Decision:** APIs públicas. Usamos exclusivamente `AXUIElementCreateApplication`, `AXUIElementCopyAttributeValue`, `AXUIElementPerformAction` y funciónes relacionadas del framework publico de macOS.
 
 **Consecuencias:**
 
 Lo que ganamos:
-- Estabilidad entre versiones de macOS. El mismo codigo funciona en macOS 13, 14 y 15 sin cambios.
-- Documentacion oficial de Apple. Cuando algo no funciona, hay referencia para entender por que.
-- No rompemos con actualizaciones de Xcode. Las APIs privadas cambian con cada beta; las publicas no.
+- Estabilidad entre versiones de macOS. El mismo código funcióna en macOS 13, 14 y 15 sin cambios.
+- Documentación oficial de Apple. Cuando algo no funcióna, hay referencia para entender por qué.
+- No rompemos con actualizaciones de Xcode. Las APIs privadas cambian con cada beta; las públicas no.
 - Legitimidad: no estamos haciendo nada que Apple no permita. Es la misma API que usan VoiceOver, Hammerspoon, y decenas de herramientas de accesibilidad.
 
 Lo que perdemos:
-- AXe puede hacer cosas que nosotros no. Por ejemplo, obtener snapshots del arbol entero en una sola llamada, sin iterar recursivamente.
+- AXe puede hacer cosas que nosotros no. Por ejemplo, obtener snapshots del árbol entero en una sola llamada, sin iterar recursivamente.
 - Algunos elementos no se exponen. Los botones de SwiftUI NavigationBar reportan `AXChildren = [0]` — existen visualmente pero la API publica no los ve. Tuvimos que implementar fallbacks con CGEvent (click por coordenadas).
 - Requiere que el usuario otorgue permiso de Accessibility en System Settings. En CI, esto se configura con `tccutil` o con perfiles MDM.
 
@@ -93,11 +93,11 @@ Lo que perdemos:
 
 **Contexto:** XCUITest es el camino "oficial" de Apple para automatizar UI en iOS. Maestro lo usa internamente (lanza un XCUITest "zombie" persistente). Appium lo usa via WebDriverAgent. Es la base de practicamente todas las herramientas del ecosistema.
 
-**Opciones:**
+**Opciónes:**
 
 1. **Usar XCUITest como capa interna** — Como hace Maestro: lanzar un test runner persistente que expone un servidor HTTP. Nuestro CLI hablaria con ese servidor. Ventaja: acceso a las APIs de matching de XCUITest (`XCUIApplication.buttons["Login"]`). Desventaja: necesitas compilar un test target, necesitas un proyecto Xcode, el runner a veces crashea y hay que reiniciarlo.
 
-2. **No usar XCUITest** — Reemplazarlo completamente con AXUIElement + CGEvent + simctl. Ventaja: cero compilacion, funciona con cualquier app instalada. Desventaja: tienes que implementar tu propio sistema de matching de elementos.
+2. **No usar XCUITest** — Reemplazarlo completamente con AXUIElement + CGEvent + simctl. Ventaja: cero compilación, funcióna con cualquier app instalada. Desventaja: tienes que implementar tu propio sistema de matching de elementos.
 
 **Decision:** No usarlo. Si lo usaramos, seriamos otro wrapper de XCUITest — como Maestro, como Appium. La propuesta de AutoPilot es que hay otro camino.
 
@@ -105,15 +105,15 @@ Lo que perdemos:
 
 Lo que ganamos:
 - No necesitas un proyecto Xcode para automatizar una app. Puedes automatizar una app descargada del App Store (en Simulador).
-- No compilas un test target. `auto tap "Login"` funciona en 89ms, no en 15 segundos de build + launch.
+- No compilas un test target. `auto tap "Login"` funcióna en 89ms, no en 15 segundos de build + launch.
 - No hay runner que crashee, no hay sesiones zombies, no hay servidor HTTP intermedio.
 - Funciona con apps de terceros: puedes automatizar Safari, Settings, cualquier app del sistema.
 
 Lo que perdemos:
-- No tenemos las APIs de matching de XCUITest. Tuvimos que implementar nuestro propio `ElementIndex` que recorre el arbol AX recursivamente y matchea por label, tipo, indice y otros atributos.
+- No tenemos las APIs de matching de XCUITest. Tuvimos que implementar nuestro propio `ElementIndex` que recorre el árbol AX recursivamente y matchea por label, tipo, índice y otros atributos.
 - XCUITest tiene `waitForExistence(timeout:)` integrado. Nosotros implementamos nuestro propio `waitFor` con polling.
 - No podemos acceder a ciertas APIs internas de la app (estado de vistas, propiedades custom). Solo vemos lo que AXUIElement expone.
-- La documentacion y los tutoriales del ecosistema iOS asumen XCUITest. Estamos fuera de ese camino.
+- La documentación y los tutoriales del ecosistema iOS asumen XCUITest. Estamos fuera de ese camino.
 
 ---
 
@@ -121,17 +121,17 @@ Lo que perdemos:
 
 **Contexto:** Los usuarios necesitan escribir secuencias de acciones automatizadas. Necesitabamos un formato para definir esos scripts. La pregunta era: ¿usamos un formato existente o creamos uno propio?
 
-**Opciones:**
+**Opciónes:**
 
 1. **YAML** — Es lo que usa Maestro (`appId: com.example.app`, `- tapOn: "Login"`). Estructurado, legible, soporte en todos los editores. Pero YAML tiene sus trampas (indentacion significativa, tipos implicitos — `yes` es boolean, `3.10` es float), y requiere un parser que mapee YAML a acciones.
 
-2. **JavaScript** — Es lo que usa Detox (`await element(by.text('Login')).tap()`). Maximo poder: condicionales, variables, funciones. Pero requiere runtime (Node/JavaScriptCore), y el poder del lenguaje se vuelve complejidad — cada script es un programa que puede fallar de formas inesperadas.
+2. **JavaScript** — Es lo que usa Detox (`await element(by.text('Login')).tap()`). Maximo poder: condicionales, variables, funciónes. Pero requiere runtime (Node/JavaScriptCore), y el poder del lenguaje se vuelve complejidad — cada script es un programa que puede fallar de formas inesperadas.
 
 3. **JSON** — Estructurado, sin ambiguedades, soporte universal. Pero verboso e incomodo de escribir a mano. Nadie quiere poner llaves y comillas para decir "tap Login".
 
-4. **Formato propio (.auto)** — Una linea = un comando. La misma sintaxis que el CLI. Sin parser complejo: split por espacios, el primer token es el comando, el resto son argumentos.
+4. **Formato propio (.auto)** — Una línea = un comando. La misma sintaxis que el CLI. Sin parser complejo: split por espacios, el primer token es el comando, el resto son argumentos.
 
-**Decision:** Formato propio. Un script `.auto` es una lista de comandos, uno por linea, con la misma sintaxis que usarias en la terminal.
+**Decision:** Formato propio. Un script `.auto` es una lista de comandos, uno por línea, con la misma sintaxis que usarias en la terminal.
 
 ```bash
 # Esto es un script .auto completo
@@ -150,29 +150,29 @@ screenshot resultado.png
 Lo que ganamos:
 - Cero curva de aprendizaje. Si sabes usar el CLI, sabes escribir un script.
 - Cero parsing overhead. No necesitamos librerias de YAML, JSON, ni un interprete de JavaScript.
-- Un script `.auto` es legible por cualquier persona, incluyendo QA no-tecnico y product managers.
-- El mismo comando funciona en terminal (`auto tap Login`) y en script (`tap Login`). No hay dos mundos.
+- Un script `.auto` es legible por cualquier persona, incluyendo QA no-técnico y product managers.
+- El mismo comando funcióna en terminal (`auto tap Login`) y en script (`tap Login`). No hay dos mundos.
 
 Lo que perdemos:
 - No hay condicionales. No puedes hacer `if elementExists("Error") then retry`. Por ahora.
 - No hay variables. No puedes hacer `email = "test@mail.com"` y reutilizarlo.
 - No hay loops. No puedes iterar sobre una lista de datos.
-- No es un estandar. Nadie mas usa `.auto`, no hay tooling del ecosistema (linters, formatters, integraciones).
+- No es un estándar. Nadie más usa `.auto`, no hay tooling del ecosistema (linters, formatters, integraciónes).
 - Eventualmente necesitaremos control flow, y tendremos que decidir si evolucionamos `.auto` o adoptamos un lenguaje existente.
 
 ---
 
 ### ADR 5: Tauri, no Electron
 
-**Contexto:** Queriamos un editor visual para scripts `.auto` — con syntax highlighting, ejecucion integrada, preview de elementos. Un IDE minimalista. Necesitaba ser una app de escritorio porque interactua con el CLI local y el Simulador.
+**Contexto:** Queriamos un editor visual para scripts `.auto` — con syntax highlighting, ejecución integrada, preview de elementos. Un IDE minimalista. Necesitaba ser una app de escritorio porque interactua con el CLI local y el Simulador.
 
-**Opciones:**
+**Opciónes:**
 
-1. **Electron** — El estandar de la industria para apps desktop con web tech. Lo usan VS Code, Slack, Discord. Ecosistema masivo, documentacion abundante, cualquier libreria de npm funciona. Pero cada app Electron empaqueta Chromium (~200MB), consume 300-500MB de RAM base, y el backend es Node.js.
+1. **Electron** — El estándar de la industria para apps desktop con web tech. Lo usan VS Code, Slack, Discord. Ecosistema masivo, documentación abundante, cualquier libreria de npm funcióna. Pero cada app Electron empaqueta Chromium (~200MB), consume 300-500MB de RAM base, y el backend es Node.js.
 
-2. **Tauri** — Backend en Rust, frontend en cualquier framework web, usa el webview nativo del OS (WebKit en macOS). Binario de ~15MB. Comunidad mas pequena pero creciendo rapido. Tauri 2 trajo estabilidad significativa.
+2. **Tauri** — Backend en Rust, frontend en cualquier framework web, usa el webview nativo del OS (WebKit en macOS). Binario de ~15MB. Comunidad más pequena pero creciendo rápido. Tauri 2 trajo estabilidad significativa.
 
-3. **App nativa SwiftUI** — Sin web, nativo puro. Minimo overhead. Pero construir un editor de codigo en SwiftUI es reinventar la rueda: syntax highlighting, autocompletado, tabs, multi-cursor — todo lo que Monaco resuelve.
+3. **App nativa SwiftUI** — Sin web, nativo puro. Minimo overhead. Pero construir un editor de código en SwiftUI es reinventar la rueda: syntax highlighting, autocompletado, tabs, multi-cursor — todo lo que Monaco resuelve.
 
 **Decision:** Tauri 2 con React + TypeScript + Monaco Editor en el frontend.
 
@@ -182,35 +182,35 @@ Lo que ganamos:
 - El editor completo pesa ~15MB vs ~200MB de Electron.
 - Monaco nos da gratis: syntax highlighting, autocompletado, multi-cursor, minimap, busqueda y reemplazo con regex.
 - El backend en Rust puede llamar al CLI `auto` directamente via `std::process::Command`.
-- WebKit en macOS es rapido y consume menos memoria que Chromium embebido.
+- WebKit en macOS es rápido y consume menos memoria que Chromium embebido.
 
 Lo que perdemos:
 - Requiere Rust toolchain instalado para compilar (`rustup`). Es un requisito extra para desarrolladores.
-- La comunidad de Tauri es mas pequena que la de Electron. Menos plugins, menos respuestas en Stack Overflow, menos ejemplos.
-- Algunas APIs de Tauri 2 cambiaron significativamente respecto a Tauri 1. La documentacion a veces esta desactualizada.
-- El webview de macOS (WebKit) tiene diferencias sutiles con Chrome. Algun CSS o API de DOM puede no funcionar identico.
+- La comúnidad de Tauri es más pequena que la de Electron. Menos plugins, menos respuestas en Stack Overflow, menos ejemplos.
+- Algunas APIs de Tauri 2 cambiaron significativamente respecto a Tauri 1. La documentación a veces esta desactualizada.
+- El webview de macOS (WebKit) tiene diferencias sutiles con Chrome. Algun CSS o API de DOM puede no funciónar identico.
 
 ---
 
 ### ADR 6: DYLD_INSERT_LIBRARIES vs force_load para camera mock
 
-**Contexto:** Implementamos un mock de camara que reemplaza AVFoundation a nivel de ObjC runtime. La pregunta era como inyectar ese dylib en la app objetivo. Teniamos dos mecanismos de inyeccion disponibles en macOS.
+**Contexto:** Implementamos un mock de cámara que reemplaza AVFoundation a nivel de ObjC runtime. La pregunta era como inyectar ese dylib en la app objetivo. Teniamos dos mecanismos de inyección disponibles en macOS.
 
-**Opciones:**
+**Opciónes:**
 
 1. **force_load via Xcode** — Agregas `-force_load /path/to/libCameraMock.dylib` en Other Linker Flags del proyecto. El dylib se carga al iniciar la app. Requiere acceso al proyecto Xcode y recompilar.
 
 2. **DYLD_INSERT_LIBRARIES** — Variable de entorno que le dice al dynamic linker de macOS que cargue un dylib adicional antes de iniciar la app. No necesitas recompilar. Se pasa como argumento a `simctl launch`: `xcrun simctl launch --env DYLD_INSERT_LIBRARIES=/path/to/mock.dylib booted com.app.bundle`.
 
-**Decision:** Soportar ambos. `force_load` para cuando tienes el proyecto y quieres integracion permanente. `DYLD_INSERT_LIBRARIES` para cuando quieres inyectar en cualquier app sin tocar su codigo.
+**Decision:** Soportar ambos. `force_load` para cuando tienes el proyecto y quieres integración permanente. `DYLD_INSERT_LIBRARIES` para cuando quieres inyectar en cualquier app sin tocar su código.
 
 ```bash
-# Opcion 1: force_load (requiere recompilar)
+# Opción 1: force_load (requiere recompilar)
 auto config project MiApp.xcodeproj
 auto config image foto.jpg
-auto build   # Agrega -force_load automaticamente
+auto build   # Agrega -force_load automáticamente
 
-# Opcion 2: DYLD (sin recompilar)
+# Opción 2: DYLD (sin recompilar)
 auto launch --env DYLD_INSERT_LIBRARIES=libCameraMock.dylib
 ```
 
@@ -218,37 +218,37 @@ auto launch --env DYLD_INSERT_LIBRARIES=libCameraMock.dylib
 
 Lo que ganamos:
 - Maxima flexibilidad. Si tienes el proyecto, usas force_load y es invisible. Si no tienes el proyecto (app de terceros, app precompilada en CI), usas DYLD.
-- Con DYLD puedes hacer hot-swap: cambias la imagen de la camara sin recompilar ni reinstalar la app.
-- El mismo dylib funciona con ambos mecanismos. No hay dos builds.
+- Con DYLD puedes hacer hot-swap: cambias la imagen de la cámara sin recompilar ni reinstalar la app.
+- El mismo dylib funcióna con ambos mecanismos. No hay dos builds.
 
 Lo que perdemos:
-- DYLD_INSERT_LIBRARIES solo funciona en el Simulador. En dispositivo fisico, code signing bloquea la carga de dylibs no firmados. Esta limitacion es fundamental y no tiene workaround.
+- DYLD_INSERT_LIBRARIES solo funcióna en el Simulador. En dispositivo físico, code signing bloquea la carga de dylibs no firmados. Esta limitación es fundamental y no tiene workaround.
 - force_load requiere acceso al proyecto Xcode. Si solo tienes el `.app` o el `.ipa`, no puedes usarlo.
-- En Xcode 26, `ENABLE_DEBUG_DYLIB=NO` es necesario para que `force_load` funcione correctamente. Es un flag poco documentado que descubrimos por trial-and-error.
-- Ambos mecanismos requieren que la app corra en Simulator. No hay forma de mockear la camara en un dispositivo fisico sin jailbreak.
+- En Xcode 26, `ENABLE_DEBUG_DYLIB=NO` es necesario para que `force_load` funcióne correctamente. Es un flag poco documentado que descubrimos por trial-and-error.
+- Ambos mecanismos requieren que la app corra en Simulator. No hay forma de mockear la cámara en un dispositivo físico sin jailbreak.
 
 ---
 
 ### ADR 7: ObjC swizzle con #undef AV_INIT_UNAVAILABLE
 
-**Contexto:** Para mockear la camara, necesitamos que `AVCapturePhotoOutput.capturePhoto(with:delegate:)` llame al delegate con un `AVCapturePhoto` que contenga nuestra imagen inyectada. El problema: `AVCapturePhoto` tiene `init` marcado como `NS_UNAVAILABLE` — Apple no quiere que lo instancies manualmente. Y necesitamos instanciarlo para pasar la foto al delegate.
+**Contexto:** Para mockear la cámara, necesitamos que `AVCapturePhotoOutput.capturePhoto(with:delegate:)` llame al delegate con un `AVCapturePhoto` que contenga nuestra imagen inyectada. El problema: `AVCapturePhoto` tiene `init` marcado como `NS_UNAVAILABLE` — Apple no quiere que lo instancies manualmente. Y necesitamos instanciarlo para pasar la foto al delegate.
 
-**Opciones:**
+**Opciónes:**
 
-1. **Subclase de AVCapturePhoto** — Crear `MockCapturePhoto : AVCapturePhoto`, override init. Crashea. ARM64 PAC (Pointer Authentication Codes) valida la vtable y los metodos internos que la subclase no implementa. El crash ocurre en profundidad, en metodos de CoreMedia que esperan estado interno valido.
+1. **Subclase de AVCapturePhoto** — Crear `MockCapturePhoto : AVCapturePhoto`, override init. Crashea. ARM64 PAC (Pointer Authentication Codes) valida la vtable y los métodos internos que la subclase no implementa. El crash ocurre en profundidad, en métodos de CoreMedia que esperan estado interno valido.
 
 2. **objc_msgSend directo** — Bypassear el compilador y llamar `[[AVCapturePhoto alloc] init]` via `objc_msgSend`. Mismo problema: PAC detecta que el objeto no fue inicializado por el path esperado y crashea.
 
-3. **#undef del macro de compilacion** — AVFoundation marca init como unavailable con un macro llamado `AV_INIT_UNAVAILABLE` definido en `AVBase.h`. Si importamos `AVBase.h` primero, hacemos `#undef AV_INIT_UNAVAILABLE`, y lo redefinimos como vacio, el compilador ve `init` como un metodo normal. La instancia se crea correctamente porque ObjC runtime no valida PAC en `alloc`+`init` regular.
+3. **#undef del macro de compilación** — AVFoundation marca init como unavailable con un macro llamado `AV_INIT_UNAVAILABLE` definido en `AVBase.h`. Si importamos `AVBase.h` primero, hacemos `#undef AV_INIT_UNAVAILABLE`, y lo redefinimos como vacio, el compilador ve `init` como un método normal. La instancia se crea correctamente porque ObjC runtime no valida PAC en `alloc`+`init` regular.
 
-**Decision:** Opcion 3. Importar `AVBase.h`, `#undef AV_INIT_UNAVAILABLE`, redefinir como vacio.
+**Decision:** Opción 3. Importar `AVBase.h`, `#undef AV_INIT_UNAVAILABLE`, redefinir como vacio.
 
 ```objc
 #import <AVFoundation/AVBase.h>
 #undef AV_INIT_UNAVAILABLE
 #define AV_INIT_UNAVAILABLE
 
-// Ahora esto compila y funciona:
+// Ahora esto compila y funcióna:
 AVCapturePhoto *photo = [[AVCapturePhoto alloc] init];
 
 // Inyectamos datos via associated objects (sin tocar ivars internos):
@@ -260,14 +260,14 @@ El truco complementario: como la instancia de `AVCapturePhoto` esta vacia (sin e
 **Consecuencias:**
 
 Lo que ganamos:
-- `[[AVCapturePhoto alloc] init]` funciona. Podemos crear instancias reales de `AVCapturePhoto` y pasarlas al delegate como si vinieran de la camara real.
-- Associated objects evitan tocar ivars internos de AVCapturePhoto. No necesitamos conocer el layout de memoria de la clase. Si Apple agrega o mueve ivars, nuestro codigo sigue funcionando.
-- Los 25 metodos swizzleados cubren todo el pipeline de AVFoundation: discovery, configuracion, sesion, captura y entrega al delegate.
+- `[[AVCapturePhoto alloc] init]` funcióna. Podemos crear instancias reales de `AVCapturePhoto` y pasarlas al delegate como si vinieran de la cámara real.
+- Associated objects evitan tocar ivars internos de AVCapturePhoto. No necesitamos conocer el layout de memoria de la clase. Si Apple agrega o mueve ivars, nuestro código sigue funciónando.
+- Los 25 métodos swizzleados cubren todo el pipeline de AVFoundation: discovery, configuración, sesion, captura y entrega al delegate.
 
 Lo que perdemos:
-- Dependemos de que Apple no cambie el nombre del macro `AV_INIT_UNAVAILABLE`. Si lo renombran, nuestro `#undef` no hace nada y la compilacion falla. Es fragil.
-- Esta tecnica solo funciona en compilacion (Clang). No podemos aplicarla en runtime — si el dylib ya esta compilado, `init` ya esta marcado como unavailable en los headers que se usaron para compilar.
-- Es ObjC puro. No hay equivalente en Swift. Todo el codigo del mock de camara esta en ObjC embebido como string en `MockHeaders.swift` y compilado con `clang` en tiempo de build.
+- Dependemos de que Apple no cambie el nombre del macro `AV_INIT_UNAVAILABLE`. Si lo renombran, nuestro `#undef` no hace nada y la compilación falla. Es frágil.
+- Esta técnica solo funcióna en compilación (Clang). No podemos aplicarla en runtime — si el dylib ya esta compilado, `init` ya esta marcado como unavailable en los headers que se usaron para compilar.
+- Es ObjC puro. No hay equivalente en Swift. Todo el código del mock de cámara esta en ObjC embebido como string en `MockHeaders.swift` y compilado con `clang` en tiempo de build.
 - Cualquier cambio interno en AVCapturePhoto (nuevos checks en init, validaciones de estado) podria romper esto sin aviso.
 
 ---
@@ -276,16 +276,16 @@ Lo que perdemos:
 
 Estas siete decisiones definen lo que AutoPilot es y lo que no es.
 
-Es un CLI Swift nativo que habla directamente con macOS. No es cross-platform. Es un formato de scripting minimalista que prioriza legibilidad sobre poder. No es un lenguaje de programacion. Es un hack de ObjC runtime que inyecta una camara que no existe. No es una solucion elegante.
+Es un CLI Swift nativo que habla directamente con macOS. No es cross-platform. Es un formato de scripting minimalista que prioriza legibilidad sobre poder. No es un lenguaje de programacion. Es un hack de ObjC runtime que inyecta una cámara que no existe. No es una solución elegante.
 
 Cada decision tiene consecuencias que aceptamos con los ojos abiertos. Algunas las revisaremos — `.auto` probablemente necesitara variables y condicionales eventualmente, y Tauri podria no ser la respuesta correcta a largo plazo. Otras son permanentes — Swift y AXUIElement son la base sobre la que todo lo demas se construye.
 
-Lo que importa no es que cada decision sea optima. Lo que importa es que cada decision este documentada con su contexto, sus alternativas y sus tradeoffs. Para nosotros en seis meses, y para cualquier ingeniero que se pregunte "¿por que no usaron XCUITest?" o "¿por que no Electron?".
+Lo que importa no es que cada decision sea optima. Lo que importa es que cada decision este documentada con su contexto, sus alternativas y sus tradeoffs. Para nosotros en seis meses, y para cualquier ingeniero que se pregunte "¿por qué no usaron XCUITest?" o "¿por qué no Electron?".
 
 La respuesta siempre esta aqui.
 
 ---
 
-*Anterior: [Capitulo 6 — Alternativas](06-alternativas.md)*
+*Anterior: [Capítulo 6 — Alternativas](06-alternativas.md)*
 
 *[Indice del libro](README.md)*

--- a/docs/libro/README.md
+++ b/docs/libro/README.md
@@ -1,4 +1,4 @@
-# AutoPilot — Ingenieria de automatizacion iOS desde macOS
+# AutoPilot — Ingeniería de automatización iOS desde macOS
 
 > "Information is power. But like all power, there are those who want to keep it for themselves.
 > The world's entire scientific and cultural heritage [...] is increasingly being digitized and locked up
@@ -7,9 +7,9 @@
 
 ---
 
-Este no es un manual de usuario. Es la documentacion tecnica de una investigacion.
+Este no es un manual de usuario. Es la documentación técnica de una investigación.
 
-AutoPilot nacio de una pregunta simple: ¿se puede controlar el Simulador iOS sin XCUITest, sin servidor, sin dependencias? La respuesta involucro APIs de accesibilidad de macOS, inyeccion de dylibs via DYLD_INSERT_LIBRARIES, swizzle de 25 metodos de AVFoundation, y 10 intentos de mockear una camara que no existe.
+AutoPilot nació de una pregunta simple: ¿se puede controlar el Simulador iOS sin XCUITest, sin servidor, sin dependencias? La respuesta involucró APIs de accesibilidad de macOS, inyección de dylibs via DYLD_INSERT_LIBRARIES, swizzle de 25 métodos de AVFoundation, y 10 intentos de mockear una cámara que no existe.
 
 Documentamos todo el proceso — los errores, los callejones sin salida, las decisiones — para que cualquier ingeniero que enfrente problemas similares tenga un punto de partida. El conocimiento es libre.
 
@@ -19,20 +19,20 @@ Documentamos todo el proceso — los errores, los callejones sin salida, las dec
 
 ### El libro
 
-1. **[El problema](01-el-problema.md)** — Por que la automatizacion iOS esta rota y que observacion lo cambio todo
+1. **[El problema](01-el-problema.md)** — Por qué la automatización iOS está rota y que observación lo cambió todo
 2. **[Arquitectura](02-arquitectura.md)** — AXUIElement, CGEvent, simctl, AppleScript: las 4 capas que reemplazan a XCUITest
-3. **[La camara virtual](03-la-camara-virtual.md)** — 10 intentos, 9 fracasos, y lo que aprendimos de cada uno
-4. **[Inyeccion sin recompilar](04-inyeccion-sin-recompilar.md)** — DYLD_INSERT_LIBRARIES como herramienta de testing (un enfoque que nadie mas usa)
+3. **[La cámara virtual](03-la-camara-virtual.md)** — 10 intentos, 9 fracasos, y lo que aprendimos de cada uno
+4. **[Inyección sin recompilar](04-inyeccion-sin-recompilar.md)** — DYLD_INSERT_LIBRARIES como herramienta de testing (un enfoque que nadie más usa)
 5. **[El editor](05-el-editor.md)** — De CLI a IDE visual con Tauri + Monaco
-6. **[Alternativas](06-alternativas.md)** — Maestro, Appium, AXe, XCUITest, idb: que hacen bien y por que elegimos otro camino
-7. **[Decisiones](07-decisiones.md)** — ADRs: por que Swift puro, por que AX publicas, por que no YAML
+6. **[Alternativas](06-alternativas.md)** — Maestro, Appium, AXe, XCUITest, idb: que hacen bien y por qué elegimos otro camino
+7. **[Decisiones](07-decisiones.md)** — ADRs: por qué Swift puro, por qué AX públicas, por qué no YAML
 
 ### Apendices
 
 - **[Referencia de comandos](apendices/comandos.md)** — Los ~30 comandos del CLI
-- **[Variables de entorno](apendices/variables-entorno.md)** — Inyeccion de datos para CI/CD
-- **[CI/CD](apendices/ci-cd.md)** — GitHub Actions, permisos TCC, configuracion de runners
-- **[Troubleshooting](apendices/troubleshooting.md)** — Errores comunes y como resolverlos
+- **[Variables de entorno](apendices/variables-entorno.md)** — Inyección de datos para CI/CD
+- **[CI/CD](apendices/ci-cd.md)** — GitHub Actions, permisos TCC, configuración de runners
+- **[Troubleshooting](apendices/troubleshooting.md)** — Errores comúnes y como resolverlos
 
 ### Referencia
 
@@ -41,16 +41,16 @@ Documentamos todo el proceso — los errores, los callejones sin salida, las dec
 
 ---
 
-## Como leer este libro
+## Cómo leer este libro
 
-Si quieres entender **por que existe** AutoPilot, lee el [Capitulo 1](01-el-problema.md).
+Si quieres entender **por qué existe** AutoPilot, lee el [Capítulo 1](01-el-problema.md).
 
-Si quieres entender **como funciona** por dentro, lee el [Capitulo 2](02-arquitectura.md).
+Si quieres entender **cómo funcióna** por dentro, lee el [Capítulo 2](02-arquitectura.md).
 
-Si quieres ver **ingenieria inversa real** — intentos fallidos, ARM64 PAC, ObjC runtime hacks, descubrimientos que no estan documentados en ningun otro lugar — lee los Capitulos [3](03-la-camara-virtual.md) y [4](04-inyeccion-sin-recompilar.md).
+Si quieres ver **ingeniería inversa real** — intentos fallidos, ARM64 PAC, ObjC runtime hacks, descubrimientos que no estan documentados en ningún otro lugar — lee los Capítulos [3](03-la-camara-virtual.md) y [4](04-inyeccion-sin-recompilar.md).
 
 Si quieres **usar** AutoPilot, ve al [README principal](../../README.md).
 
 ---
 
-*Todo el contenido esta en espanol. El codigo fuente y los ejemplos usan convenciones en ingles donde es idiomatico (nombres de funciones, variables, APIs).*
+*Todo el contenido esta en español. El código fuente y los ejemplos usan convenciones en ingles donde es idiomático (nombres de funciónes, variables, APIs).*


### PR DESCRIPTION
## Summary

Reestructuración completa de la documentación como libro técnico de investigación abierta. Inspirado en pointfreeco y el espíritu de Aaron Swartz.

- README reducido de 578 a 127 líneas (contraportada, no el libro)
- 7 capítulos nuevos en `docs/libro/` (1,500+ líneas)
- Skill `/docs` para mantener la documentación con esta filosofía
- Acentos y ñ corregidos en toda la documentación

### Capítulos

| # | Capítulo | Líneas | Contenido |
|---|---|---|---|
| 01 | El problema | 90 | Por qué la automatización iOS está rota |
| 02 | Arquitectura | 168 | AXUIElement, CGEvent, simctl, AppleScript |
| 03 | La cámara virtual | 196 | 10 intentos, 9 fracasos |
| 04 | Inyección sin recompilar | 174 | DYLD_INSERT_LIBRARIES en testing |
| 05 | El editor | 112 | De CLI a IDE visual con Tauri + Monaco |
| 06 | Alternativas | 419 | Maestro, Appium, AXe, Detox, idb, XCUITest |
| 07 | Decisiones | 291 | 7 ADRs: Swift, AX públicas, no YAML, Tauri |

### Filosofía

El conocimiento es libre. Este repo documenta la investigación — los errores, los tropiezos, los descubrimientos — para que cualquier ingeniero que enfrente problemas similares tenga un punto de partida.

## Test plan

- [ ] Verificar que los links entre capítulos funcionan en GitHub
- [ ] Verificar que los diagramas Mermaid renderizan
- [ ] Revisar acentos y ñ en los 9 archivos

🤖 Generated with [Claude Code](https://claude.com/claude-code)