### PR TITLE
feat: element index Android en editor — autocomplete de 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ auto launch
 - Con `--legacy`: `uiautomator dump` toma 1-2 segundos (el AgentBridge default no tiene este problema)
 - Clipboard read no soportado via ADB (solo write como workaround)
 - Camera mock no implementado aun en Android
-- El editor Tauri aun no soporta Android (busca binario `auto` hardcodeado)
+- Element index `$N` en Android se genera en el editor (Rust), no en el CLI — `auto-android index` aun no existe
 
 ### General
 - El editor necesita Rust toolchain instalado (`rustup`)

--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -99,6 +99,7 @@ Esto permite que `TreePrinter.printAX()` y `CommandDispatcher` funcionen identic
 | Entrada | CGEvent (kernel, ~50ms) | injectInputEvent (~1-3ms) |
 | Latencia total de tap | ~90ms | ~150ms (find + inject via socket) |
 | Permisos | TCC Accesibilidad | USB debugging habilitado |
+| Element index ($N) | `auto index` (CLI nativo) | `index_from_tree()` en Rust del editor ([ver cap. 5](../libro/05-el-editor.md#element-index-en-android)) |
 | Camera mock | DYLD_INSERT_LIBRARIES | No implementado aun |
 | Clipboard read | `simctl pbpaste` | No soportado via ADB |
 | Biometrico | AppleScript menus Face ID | `adb -e emu finger touch` (pendiente) |

--- a/docs/camera/BITACORA.md
+++ b/docs/camera/BITACORA.md
@@ -583,3 +583,13 @@ Después de validar el agente, conectamos el CLI `auto-android` al socket:
 **Tropiezo adicional:** Cargo no recompilaba el editor después de editar `lib.rs` con Claude Code. El tool Edit no actualiza el mtime del archivo de forma que cargo lo detecte. Solución: `touch -t` con timestamp futuro para forzar recompilación.
 
 **Resultado:** Inspect funciona en Android — screenshot + tree en ~500ms (paralelo).
+
+### Editor — Element index Android
+
+**Problema:** `get_element_index` devolvia `[]` para Android — sin autocomplete de `$N` en el editor.
+
+**Causa:** El CLI iOS genera indices con `auto index`, pero no existia equivalente en Android.
+
+**Solucion:** `index_from_tree()` en el backend Rust del editor. Genera indices `$N` directamente desde el arbol de accesibilidad. Resuelve nodos genericos "View" (tipicos de Compose) usando el texto de hijos, y omite contenedores sin informacion util (FrameLayout, LinearLayout en profundidad 0-1). Se integro en `get_element_index` e `inspect`.
+
+**Resultado:** Autocomplete de elementos `$N` funciona en Android. El inspector muestra indices clickeables para ambas plataformas.

--- a/docs/libro/05-el-editor.md
+++ b/docs/libro/05-el-editor.md
@@ -92,7 +92,7 @@ editor/
 │       └── lib.rs          # Comandos invoke()
 │           ├── run_auto(args, platform)    # Ejecuta auto o auto-android
 │           ├── get_ax_tree(platform)       # Arbol de accesibilidad
-│           ├── get_element_index(platform) # Indices $N (iOS only)
+│           ├── get_element_index(platform) # Indices $N (iOS y Android)
 │           ├── inspect(platform)           # Screenshot + tree + index
 │           └── open_screenshots            # Abrir carpeta de capturas
 ```
@@ -122,8 +122,12 @@ En Rust, `auto_binary(platform)` busca el binario en varias ubicaciones: junto a
 | Binario | `auto` | `auto-android` |
 | Play/tap/tree | Funciona | Funciona |
 | Inspector screenshot | Funciona | Funciona (via adb screencap) |
-| Element index ($N) | Funciona | No disponible (devuelve vacío) |
+| Element index ($N) | Funciona | Funciona (via `index_from_tree` en Rust) |
 | Auto-wait (AXObserver) | Funciona | No disponible |
+
+### Element index en Android
+
+En iOS, el element index (`$N`) se genera desde `auto index` en el CLI. En Android no existia un equivalente — `get_element_index` devolvia `[]`. La solucion fue `index_from_tree()` en el backend Rust del editor: genera los indices `$N` directamente desde el arbol de accesibilidad. Resuelve nodos genericos ("View" en Compose) usando el texto de sus hijos, y omite contenedores puros (FrameLayout, LinearLayout en profundidad 0-1) que no aportan informacion util. Tanto `get_element_index` como `inspect` ahora generan el indice para Android.
 
 ### Limitaciones actuales
 

--- a/editor/src-tauri/src/lib.rs
+++ b/editor/src-tauri/src/lib.rs
@@ -140,6 +140,48 @@ fn parse_tree_output(stdout: &str) -> (Vec<Value>, Vec<String>) {
     (elements, labels)
 }
 
+/// Build indexed element list from parsed tree elements.
+/// For Android: resolves generic "View" nodes by looking at their child text.
+fn index_from_tree(elements: &[Value]) -> Vec<Value> {
+    let mut indexed: Vec<Value> = Vec::new();
+    let mut idx: i64 = 0;
+
+    for el in elements {
+        let role = el["role"].as_str().unwrap_or("");
+        let label = el["label"].as_str().unwrap_or("");
+        let frame = el["frame"].as_str().unwrap_or("");
+        let depth = el["depth"].as_i64().unwrap_or(0);
+
+        // Skip pure containers with no useful info at depth 0-1
+        if depth <= 1 && label.is_empty() && matches!(role, "FrameLayout" | "LinearLayout") {
+            continue;
+        }
+
+        // For "View" or "Button" without a label, look at sibling/neighbor context
+        // The display field already has the best label from parse_tree_output
+        let display = el["display"].as_str().unwrap_or("");
+
+        let effective_label = if !label.is_empty() {
+            label.to_string()
+        } else if !display.is_empty() && display != role {
+            display.to_string()
+        } else {
+            // Skip elements with no useful identifier
+            continue;
+        };
+
+        indexed.push(serde_json::json!({
+            "index": idx,
+            "role": role,
+            "label": effective_label,
+            "frame": frame,
+        }));
+        idx += 1;
+    }
+
+    indexed
+}
+
 #[tauri::command]
 fn get_ax_tree(platform: Option<String>) -> Result<Value, String> {
     let plat = platform.as_deref().unwrap_or("ios");
@@ -157,8 +199,13 @@ fn get_ax_tree(platform: Option<String>) -> Result<Value, String> {
 #[tauri::command]
 fn get_element_index(platform: Option<String>) -> Result<Value, String> {
     let plat = platform.as_deref().unwrap_or("ios");
+
     if plat == "android" {
-        return Ok(serde_json::json!({ "elements": [] }));
+        // Generate index from tree — flatten elements and resolve generic Views
+        let bin = auto_binary(plat);
+        let stdout = run_cli(&bin, &["tree"]).unwrap_or_default();
+        let (elements, _) = parse_tree_output(&stdout);
+        return Ok(serde_json::json!({ "elements": index_from_tree(&elements) }));
     }
 
     let bin = auto_binary(plat);
@@ -261,19 +308,19 @@ fn inspect(platform: Option<String>) -> Result<Value, String> {
         Ok(parse_tree_output(&stdout))
     });
 
-    // Index (skip for Android)
-    let index_elements = if plat == "android" {
-        Vec::new()
-    } else {
-        let index_result = get_element_index(Some(plat.to_string()))?;
-        index_result["elements"].as_array().cloned().unwrap_or_default()
-    };
-
     // Collect results
     let image_b64 = screenshot_thread.join().unwrap_or_default();
     let (elements, labels) = tree_thread.join()
         .map_err(|_| "Tree thread panicked".to_string())?
         .map_err(|e| format!("Tree failed: {}", e))?;
+
+    // Index: for Android, generate from tree; for iOS, call `auto index`
+    let index_elements = if plat == "android" {
+        index_from_tree(&elements)
+    } else {
+        let index_result = get_element_index(Some(plat.to_string()))?;
+        index_result["elements"].as_array().cloned().unwrap_or_default()
+    };
 
     Ok(serde_json::json!({
         "screenshot": format!("data:image/png;base64,{}", image_b64),


### PR DESCRIPTION
## Summary
- El editor ahora genera elementos indexados `$N` para Android desde el tree
- `index_from_tree()` en Rust: aplana el árbol, resuelve Views genéricos, skipea containers vacíos
- Inspect y get_element_index devuelven índices para Android (antes: lista vacía)

## Cómo funciona
Los Views genéricos de Compose (`View [96,1701 1088x168]`) no tienen texto propio. `index_from_tree()` usa el `display` field (que viene del parsing del tree) para darle un label útil. Skipea `FrameLayout`/`LinearLayout` a profundidad 0-1 que son solo containers.

## Docs actualizados
- Cap. 5: tabla "Element index → Funciona" + nueva sección explicativa
- docs/android: fila en tabla de diferencias
- CLAUDE.md: limitación actualizada
- Bitácora: entrada del fix

## Test plan
- [x] Inspect Android muestra elementos indexados (no vacío)
- [x] Autocomplete incluye labels de la UI
- [x] iOS sigue usando `auto index` (sin cambios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)