### PR TITLE
docs: bitácora PRs #17-#18, refs biometric actualizadas

### DIFF
--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -68,6 +68,11 @@ Todos los comandos del protocolo `DeviceBridge` estan disponibles:
 | `auto-android waitFor "texto" 10` | Polling cada 500ms, timeout configurable | **Funcional** |
 | `auto-android openurl <url>` | `am start -a VIEW -d <url>` | **Funcional** |
 | `auto-android media <img>` | `push` + media scanner broadcast | **Funcional** |
+| `auto-android biometric enroll` | `locksettings set-pin` + `emu finger touch` x15 | **Funcional** |
+| `auto-android biometric unenroll` | `locksettings clear --old 1234` | **Funcional** |
+| `auto-android biometric match` | `adb -e emu finger touch 1` | **Funcional** |
+| `auto-android biometric fail` | `adb -e emu finger touch 0` | **Funcional** |
+| `auto-android biometric status` | `locksettings get-disabled` | **Funcional** |
 
 ## UIAutomatorParser — El puente entre XML y TreePrinter
 
@@ -102,7 +107,7 @@ Esto permite que `TreePrinter.printAX()` y `CommandDispatcher` funcionen identic
 | Element index ($N) | `auto index` (CLI nativo) | `index_from_tree()` en Rust del editor ([ver cap. 5](../libro/05-el-editor.md#element-index-en-android)) |
 | Camera mock | DYLD_INSERT_LIBRARIES | No implementado aun |
 | Clipboard read | `simctl pbpaste` | No soportado via ADB |
-| Biometrico | AppleScript menus Face ID | `adb -e emu finger touch` (pendiente) |
+| Biometrico | AppleScript menus Face ID | `adb -e emu finger touch` + `locksettings` (enroll/match/fail/status) |
 
 ## Prerequisitos
 

--- a/docs/camera/BITACORA.md
+++ b/docs/camera/BITACORA.md
@@ -593,3 +593,79 @@ Después de validar el agente, conectamos el CLI `auto-android` al socket:
 **Solucion:** `index_from_tree()` en el backend Rust del editor. Genera indices `$N` directamente desde el arbol de accesibilidad. Resuelve nodos genericos "View" (tipicos de Compose) usando el texto de hijos, y omite contenedores sin informacion util (FrameLayout, LinearLayout en profundidad 0-1). Se integro en `get_element_index` e `inspect`.
 
 **Resultado:** Autocomplete de elementos `$N` funciona en Android. El inspector muestra indices clickeables para ambas plataformas.
+
+### Unificacion de labels de auth (PR #17)
+
+**Problema:** Los scripts de login para iOS y Android usaban labels diferentes para los mismos elementos UI. La app iOS decia "Ingresa tu codigo" y la Android "Ingresa tu PIN". Los scripts no eran intercambiables sin editar labels.
+
+**Cambios:**
+- Unificamos los labels de autenticacion en ambas apps demo (iOS y Android) para que coincidan
+- Apps demo iOS (`Test Automatitacion`): AuthView reescrita con labels consistentes
+- App demo Android (`TestAutomatitacion`): MainActivity actualizada con mismos labels
+- Scripts `.auto` actualizados para usar labels unificados
+- Workflow de CI actualizado para reflejar los nuevos labels
+
+**Archivos tocados:**
+- `Demo/iOS/Test Automatitacion/` — AuthView, ContentView, AppState, modelos, tema
+- `Demo/Android/TestAutomatitacion/` — MainActivity.kt
+- `scripts/examples/login.auto`, `scripts/examples/android-login.auto`
+- `.github/workflows/camera-test.yml`
+
+**Resultado:** El mismo script `.auto` funciona en ambas plataformas sin cambiar labels. Un paso mas hacia scripts verdaderamente cross-platform.
+
+### Comando biometric cross-platform (PR #18)
+
+**Contexto:** El comando `faceid` solo existia para iOS (AppleScript → menus del Simulador). Android no tenia soporte biometrico. Ademas, el nombre "faceid" era especifico de Apple.
+
+**Diseño:**
+- Nuevo comando generico `biometric` con 5 subcomandos: `enroll`, `unenroll`, `match`, `fail`, `status`
+- 5 metodos nuevos en el protocolo `DeviceBridge`: `biometricEnroll()`, `biometricUnenroll()`, `biometricMatch()`, `biometricFail()`, `biometricIsEnrolled()`
+- `faceid` se mantiene como alias legacy en el dispatcher
+
+**Implementacion iOS (SimulatorBridge):**
+- Misma mecanica que antes: AppleScript via System Events para controlar menus del Simulador
+- `enroll/unenroll`: toggle del menu item "Enrolled" bajo Features > Face ID
+- `match/fail`: click en "Matching Face" / "Non-matching Face"
+- `status`: lee `AXMenuItemMarkChar` para detectar si tiene checkmark
+
+**Implementacion Android (AdbLegacyBridge):**
+- `biometricEnroll()`: flujo completamente automatizado:
+  1. Verifica si ya esta enrollado (`biometricIsEnrolled()`) — idempotente
+  2. Configura PIN via `locksettings set-pin 1234`
+  3. Lanza `android.settings.BIOMETRIC_ENROLL`
+  4. Navega pantallas de consentimiento con taps automaticos
+  5. Simula 15 toques de fingerprint via `adb -e emu finger touch 1`
+- `biometricUnenroll()`: `locksettings clear --old 1234`
+- `biometricMatch()`: `adb -e emu finger touch 1`
+- `biometricFail()`: `adb -e emu finger touch 0`
+- `biometricIsEnrolled()`: verifica via `locksettings get-disabled` (false = PIN activo = fingerprint enrollado)
+
+**Tropiezos resueltos:**
+1. **PIN existente:** `locksettings set-pin` falla si ya hay PIN. Solucion: detectar y agregar `--old 1234`
+2. **Enroll idempotente:** Si ya esta enrollado, no repetir el flujo de 15 toques
+3. **Deteccion real de enrollment:** Inicialmente hardcodeado `true`, cambiado a usar `locksettings` para deteccion real via `dumpsys`
+
+**Script cross-platform:**
+```
+biometric enroll
+biometric status
+biometric match
+```
+Funciona identico en iOS y Android — mismo comando, diferente backend.
+
+**Archivos:**
+- `cli/Sources/AutoCore/DeviceBridge.swift` — 5 metodos nuevos en protocolo
+- `cli/Sources/AutoCore/CommandDispatcher.swift` — dispatch de `biometric` + alias `faceid`
+- `cli/Sources/AutoLibiOS/SimulatorBridge.swift` — implementacion iOS
+- `cli/Sources/AutoCore/AgentBridge.swift` — delega a AdbLegacyBridge
+- `cli/Sources/AutoCore/AdbLegacyBridge.swift` — implementacion Android completa
+- `scripts/examples/hardware-test.auto` — script de prueba cross-platform
+
+### PRs de la sesion (continuacion)
+
+| PR | Titulo | Estado |
+|---|---|---|
+| #15 | Fix editor Inspect Android | Mergeado |
+| #16 | Element index Android en editor | Mergeado |
+| #17 | Unificar labels de auth | Mergeado |
+| #18 | Comando biometric cross-platform | Mergeado |

--- a/docs/libro/02-arquitectura.md
+++ b/docs/libro/02-arquitectura.md
@@ -15,7 +15,7 @@ El backend iOS se construye sobre 4 APIs de macOS. Cada una resuelve un problema
 | **Lectura** | AXUIElement | Ver la UI de la app | `auto tree`, `auto exists "Login"` |
 | **Entrada** | CGEvent | Simular interacción humana | `auto type "Hola"`, `auto swipe up` |
 | **Control** | xcrun simctl | Gestionar el Simulador | `auto launch`, `auto screenshot` |
-| **Menus** | AppleScript | Acceder a menus nativos | `auto faceid match` |
+| **Menus** | AppleScript | Acceder a menus nativos | `auto biometric match` |
 
 Ninguna de estas APIs es nueva o experimental. AXUIElement existe desde macOS 10.2 (2002). CGEvent desde 10.4 (2005). `simctl` desde Xcode 6 (2014). AppleScript desde System 7 (1993). Lo que es nuevo es usarlas *juntas* para controlar un Simulador iOS sin XCUITest.
 
@@ -128,7 +128,7 @@ Lo que agrega AutoPilot sobre simctl puro:
 
 ## Capa 4: AppleScript — El ultimo recurso
 
-Face ID no tiene API, ni en simctl ni en accesibilidad. Vive en el menu `Features > Face ID` del Simulador. La única forma de acceder es automatizar el menu con AppleScript.
+Face ID no tiene API, ni en simctl ni en accesibilidad. Vive en el menu `Features > Face ID` del Simulador. La única forma de acceder es automatizar el menu con AppleScript. El comando `biometric` (antes `faceid`) abstrae esto para ambas plataformas — en Android usa `adb emu finger touch` + `locksettings`.
 
 ```applescript
 tell application "System Events" to tell process "Simulator"
@@ -160,9 +160,10 @@ Terminal
     |
     ├─ Capa 3 (simctl): xcrun simctl io <device> screenshot resultado.png
     |
-    auto faceid match
+    auto biometric match
     |
-    └─ Capa 4 (AppleScript): click menu item "Matching Face" of menu "Face ID"...
+    └─ iOS: Capa 4 (AppleScript): click menu item "Matching Face" of menu "Face ID"...
+    └─ Android: adb -e emu finger touch 1
 ```
 
 La documentación técnica completa con diagramas Mermaid de cada flujo está en [docs/ios/ARQUITECTURA.md](../ios/ARQUITECTURA.md).

--- a/docs/libro/07-decisiones.md
+++ b/docs/libro/07-decisiones.md
@@ -300,7 +300,7 @@ cli/Sources/
 
 La clave fue que el bridge Android no necesita ningún framework de macOS — solo `Foundation` + sockets TCP. `AgentBridge` habla con un agente nativo en el dispositivo via `LocalServerSocket`. El viejo `AdbLegacyBridge` (que forkeaba `adb` por cada comando) se archivó para benchmarks. Ambos viven en `AutoCore`.
 
-Cada `main.swift` maneja sus comandos específicos de plataforma (iOS: ping, faceid, camera, build, inject, inspect; Android: ping con info de device) y delega el resto al dispatcher compartido.
+Cada `main.swift` maneja sus comandos específicos de plataforma (iOS: ping, camera, build, inject, inspect; Android: ping con info de device) y delega el resto al dispatcher compartido. El comando `biometric` (antes `faceid`) es cross-platform y vive en el dispatcher.
 
 **Consecuencias:**
 


### PR DESCRIPTION
## Summary
- **Bitácora**: entradas para PR #17 (unificación labels auth) y PR #18 (comando biometric cross-platform) con diseño, implementación iOS/Android, tropiezos resueltos
- **Android README**: biométrico ya no es "pendiente", 5 comandos `biometric` agregados a tabla de comandos
- **Libro cap. 2 y 7**: `faceid` → `biometric`, refs actualizadas a cross-platform

## Test plan
- [ ] Verificar que links internos del libro siguen funcionando
- [ ] Revisar formato de tablas en bitácora y android README

🤖 Generated with [Claude Code](https://claude.com/claude-code)