### PR TITLE
feat: benchmark CI — AutoPilot vs Maestro

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,137 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Cache: Swift build ───────────────────────────
+      - name: Cache Swift build
+        uses: actions/cache@v4
+        with:
+          path: cli/.build
+          key: swift-${{ hashFiles('cli/Sources/**/*.swift', 'cli/Package.swift') }}
+          restore-keys: swift-
+
+      # ── Cache: Maestro ───────────────────────────────
+      - name: Cache Maestro
+        uses: actions/cache@v4
+        id: maestro-cache
+        with:
+          path: ~/.maestro
+          key: maestro-v1
+
+      # ── Java 17 (Maestro necesita JVM) ───────────────
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      # ── Install Maestro ──────────────────────────────
+      - name: Install Maestro
+        if: steps.maestro-cache.outputs.cache-hit != 'true'
+        run: curl -Ls "https://get.maestro.mobile.dev" | bash
+
+      - name: Verify Maestro
+        run: |
+          export PATH="$HOME/.maestro/bin:$PATH"
+          maestro --version
+
+      # ── Build CLI + Boot Simulator (paralelo) ────────
+      - name: Build CLI + Boot Simulator
+        run: |
+          # Build en background
+          (cd cli && swift build -c release && cp .build/release/auto ../auto) &
+          BUILD_PID=$!
+
+          # Boot simulator mientras compila
+          DEVICE_UDID=$(xcrun simctl list devices available -j | python3 -c "
+          import json, sys
+          data = json.loads(sys.stdin.read())
+          for runtime, devices in data['devices'].items():
+            if 'iOS' in runtime:
+              for d in devices:
+                if d['isAvailable'] and 'iPhone' in d['name']:
+                  print(d['udid'])
+                  sys.exit(0)
+          sys.exit(1)
+          ")
+          xcrun simctl boot "$DEVICE_UDID" 2>/dev/null || true
+          echo "DEVICE_UDID=$DEVICE_UDID" >> $GITHUB_ENV
+          open -a Simulator &
+
+          # Esperar ambos
+          wait $BUILD_PID
+          xcrun simctl bootstatus "$DEVICE_UDID"
+          ./auto ping
+
+      # ── Build + Install test app ─────────────────────
+      - name: Cache Test App
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Test_Automatitacion*
+          key: test-app-${{ hashFiles('Demo/iOS/Test Automatitacion/**') }}
+          restore-keys: test-app-
+
+      - name: Build Test Automatitacion
+        run: |
+          ./auto build \
+            -project "Demo/iOS/Test Automatitacion/Test Automatitacion.xcodeproj" \
+            -scheme "Test Automatitacion" \
+            -sdk iphonesimulator \
+            -destination "id=$DEVICE_UDID"
+
+      - name: Install Test App
+        run: |
+          APP=$(find ~/Library/Developer/Xcode/DerivedData \
+            -path '*/Test_Automatitacion*/Build/Products/Debug-iphonesimulator/*.app' \
+            -maxdepth 5 | head -1)
+          if [ -z "$APP" ]; then
+            echo "ERROR: App not found in DerivedData"
+            exit 1
+          fi
+          xcrun simctl install booted "$APP"
+
+      # ── Run benchmarks ───────────────────────────────
+      - name: Run benchmarks
+        run: |
+          export PATH="$HOME/.maestro/bin:$PATH"
+          scripts/benchmarks/run-benchmark.sh
+        env:
+          AUTOPILOT_BIN: ./auto
+          MAESTRO_BIN: maestro
+          RESULTS_DIR: benchmark-results
+
+      # ── Generate report ──────────────────────────────
+      - name: Generate report
+        if: always()
+        run: scripts/benchmarks/generate-report.sh
+        env:
+          RESULTS_DIR: benchmark-results
+
+      # ── Post to job summary ──────────────────────────
+      - name: Post summary
+        if: always()
+        run: |
+          if [ -f benchmark-results/benchmark-report.md ]; then
+            cat benchmark-results/benchmark-report.md >> $GITHUB_STEP_SUMMARY
+          fi
+
+      # ── Upload artifacts ─────────────────────────────
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: |
+            benchmark-results/all-results.jsonl
+            benchmark-results/benchmark-report.md
+            benchmark-results/summary.json

--- a/scripts/benchmarks/biometric-helpers.js
+++ b/scripts/benchmarks/biometric-helpers.js
@@ -1,0 +1,19 @@
+// Helper para Maestro: biometric via xcrun simctl
+// Maestro no tiene comandos nativos de biometric,
+// asi que usamos runScript con java.lang.Runtime
+
+const action = ENV.ACTION;
+
+if (action === 'unenroll') {
+    java.lang.Runtime.getRuntime()
+        .exec('xcrun simctl spawn booted notifyutil -s com.apple.BiometricKit.enrollmentChanged 0')
+        .waitFor();
+} else if (action === 'enroll') {
+    java.lang.Runtime.getRuntime()
+        .exec('xcrun simctl spawn booted notifyutil -s com.apple.BiometricKit.enrollmentChanged 1')
+        .waitFor();
+} else if (action === 'match') {
+    java.lang.Runtime.getRuntime()
+        .exec('xcrun simctl spawn booted notifyutil -p com.apple.BiometricKit.fingerTouch.ack')
+        .waitFor();
+}

--- a/scripts/benchmarks/biometric.auto
+++ b/scripts/benchmarks/biometric.auto
@@ -1,0 +1,18 @@
+# Benchmark: Biometric flow
+# AutoPilot tiene comandos nativos para biometric
+# Maestro necesita shell out a xcrun simctl
+
+ping
+biometric unenroll
+wait 1
+biometric enroll
+wait 1
+terminate dev.autopilot.test.Explorea
+wait 1
+launch dev.autopilot.test.Explorea
+wait 1
+waitFor "Desbloquear con biometría" 10
+wait 3
+tap "Desbloquear con biometría"
+wait 1
+biometric match

--- a/scripts/benchmarks/biometric.yaml
+++ b/scripts/benchmarks/biometric.yaml
@@ -1,0 +1,29 @@
+appId: dev.autopilot.test.Explorea
+---
+# Benchmark: Biometric flow (Maestro)
+# Maestro no tiene biometric nativo — usa runScript + xcrun simctl
+
+- runScript:
+    file: biometric-helpers.js
+    env:
+      ACTION: unenroll
+
+- runScript:
+    file: biometric-helpers.js
+    env:
+      ACTION: enroll
+
+- stopApp
+
+- launchApp
+
+- assertVisible:
+    text: "Desbloquear con biometría"
+    timeout: 10000
+
+- tapOn: "Desbloquear con biometría"
+
+- runScript:
+    file: biometric-helpers.js
+    env:
+      ACTION: match

--- a/scripts/benchmarks/generate-report.sh
+++ b/scripts/benchmarks/generate-report.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RESULTS_DIR="${RESULTS_DIR:-benchmark-results}"
+REPORT="$RESULTS_DIR/benchmark-report.md"
+
+python3 << 'PYEOF' "$RESULTS_DIR" "$REPORT"
+import json, sys, os, datetime
+from collections import defaultdict
+
+results_dir = sys.argv[1]
+report_path = sys.argv[2]
+
+# ── Parse resultados ──────────────────────────────
+data = defaultdict(list)       # (tool, test) -> [total_ms...]
+failures = defaultdict(int)    # (tool, test) -> count
+
+input_file = os.path.join(results_dir, "all-results.jsonl")
+with open(input_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        r = json.loads(line)
+        key = (r["tool"], r["test"])
+        if r["exit_code"] == 0:
+            data[key].append(r["total_ms"])
+        else:
+            failures[key] += 1
+
+# ── Estadisticas ──────────────────────────────────
+def stats(values):
+    if not values:
+        return {"min": 0, "avg": 0, "max": 0, "p95": 0, "n": 0}
+    values = sorted(values)
+    n = len(values)
+    p95_idx = min(int(n * 0.95), n - 1)
+    return {
+        "min": values[0],
+        "avg": int(sum(values) / n),
+        "max": values[-1],
+        "p95": values[p95_idx],
+        "n": n
+    }
+
+tests = sorted(set(t for _, t in data.keys()))
+tools = ["autopilot", "maestro"]
+
+# ── Generar reporte ───────────────────────────────
+lines = []
+lines.append("# Benchmark: AutoPilot vs Maestro")
+lines.append("")
+lines.append(f"Generated: {datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')}")
+lines.append("")
+lines.append("## Methodology")
+lines.append("")
+lines.append("- 10 measured runs per tool per test (1 warm-up discarded)")
+lines.append("- App terminated between runs for clean state")
+lines.append("- Same simulator, same app, same session")
+lines.append("- Maestro uses `runScript` for biometric (no native support)")
+lines.append("")
+
+for test in tests:
+    lines.append(f"## Test: {test}")
+    lines.append("")
+    lines.append("| Metric | AutoPilot | Maestro | Delta |")
+    lines.append("|--------|-----------|---------|-------|")
+
+    s = {}
+    for tool in tools:
+        s[tool] = stats(data.get((tool, test), []))
+
+    for metric in ["min", "avg", "max", "p95"]:
+        ap = s["autopilot"][metric]
+        ma = s["maestro"][metric]
+        if ma > 0:
+            delta_pct = ((ap - ma) / ma) * 100
+            delta_str = f"{delta_pct:+.1f}%"
+        else:
+            delta_str = "N/A"
+
+        # Formato: segundos con 1 decimal para legibilidad
+        ap_str = f"{ap/1000:.1f}s" if ap >= 1000 else f"{ap}ms"
+        ma_str = f"{ma/1000:.1f}s" if ma >= 1000 else f"{ma}ms"
+        lines.append(f"| {metric.upper()} | {ap_str} | {ma_str} | {delta_str} |")
+
+    ap_f = failures.get(("autopilot", test), 0)
+    ma_f = failures.get(("maestro", test), 0)
+    lines.append(f"| Runs (ok/fail) | {s['autopilot']['n']}/{ap_f} | {s['maestro']['n']}/{ma_f} | |")
+    lines.append("")
+
+# ── Resumen ───────────────────────────────────────
+lines.append("## Summary")
+lines.append("")
+
+ap_total = sum(stats(data.get(("autopilot", t), []))["avg"] for t in tests)
+ma_total = sum(stats(data.get(("maestro", t), []))["avg"] for t in tests)
+
+if ap_total < ma_total:
+    pct = ((ma_total - ap_total) / ma_total) * 100
+    lines.append(f"**AutoPilot** was **{pct:.0f}% faster** on average ({ap_total/1000:.1f}s vs {ma_total/1000:.1f}s combined).")
+elif ma_total < ap_total:
+    pct = ((ap_total - ma_total) / ap_total) * 100
+    lines.append(f"**Maestro** was **{pct:.0f}% faster** on average ({ma_total/1000:.1f}s vs {ap_total/1000:.1f}s combined).")
+else:
+    lines.append("Both tools had identical average times.")
+
+lines.append("")
+lines.append("---")
+lines.append("*Benchmark ran on GitHub Actions macos-15 runner.*")
+
+report_content = "\n".join(lines) + "\n"
+
+# Escribir reporte markdown
+with open(report_path, "w") as f:
+    f.write(report_content)
+
+# Escribir summary JSON
+summary = {}
+for tool in tools:
+    summary[tool] = {}
+    for test in tests:
+        summary[tool][test] = stats(data.get((tool, test), []))
+        summary[tool][test]["failures"] = failures.get((tool, test), 0)
+
+with open(os.path.join(results_dir, "summary.json"), "w") as f:
+    json.dump(summary, f, indent=2)
+
+# Stdout
+print(report_content)
+PYEOF
+
+echo "Report: $REPORT"

--- a/scripts/benchmarks/login.auto
+++ b/scripts/benchmarks/login.auto
@@ -1,0 +1,14 @@
+# Benchmark: Login + navegacion
+# Interaccion UI pura — terreno natural de Maestro
+
+launch dev.autopilot.test.Explorea
+waitFor "Explorea" 10
+tap "Desbloquear con código"
+waitFor "Ingresa tu código" 5
+tap "1"
+tap "2"
+tap "3"
+tap "4"
+waitFor "Inicio" 5
+tap "Aventura"
+swipe up

--- a/scripts/benchmarks/login.yaml
+++ b/scripts/benchmarks/login.yaml
@@ -1,0 +1,31 @@
+appId: dev.autopilot.test.Explorea
+---
+# Benchmark: Login + navegacion (Maestro)
+# UI pura — terreno natural de Maestro
+
+- launchApp
+
+- assertVisible:
+    text: "Explorea"
+    timeout: 10000
+
+- tapOn: "Desbloquear con código"
+
+- assertVisible:
+    text: "Ingresa tu código"
+    timeout: 5000
+
+- tapOn: "1"
+- tapOn: "2"
+- tapOn: "3"
+- tapOn: "4"
+
+- assertVisible:
+    text: "Inicio"
+    timeout: 5000
+
+- tapOn: "Aventura"
+
+- swipe:
+    direction: UP
+    duration: 400

--- a/scripts/benchmarks/run-benchmark.sh
+++ b/scripts/benchmarks/run-benchmark.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Config ──────────────────────────────────────────
+TOTAL_RUNS="${TOTAL_RUNS:-11}"       # 1 warm-up + 10 medidas
+WARMUP_RUNS=1
+MEASURED_RUNS=$((TOTAL_RUNS - WARMUP_RUNS))
+RESULTS_DIR="${RESULTS_DIR:-benchmark-results}"
+AUTOPILOT_BIN="${AUTOPILOT_BIN:-./auto}"
+MAESTRO_BIN="${MAESTRO_BIN:-$HOME/.maestro/bin/maestro}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUNDLE_ID="dev.autopilot.test.Explorea"
+
+mkdir -p "$RESULTS_DIR"
+
+# ── Timing (macOS date no soporta %N) ──────────────
+now_ms() {
+  python3 -c "import time; print(int(time.time()*1000))"
+}
+
+# ── Run single ─────────────────────────────────────
+# Args: tool test_name run_number command...
+run_single() {
+  local tool="$1" test_name="$2" run_number="$3"
+  shift 3
+
+  local start_ms end_ms total_ms exit_code
+  start_ms=$(now_ms)
+
+  set +e
+  "$@" > /dev/null 2>&1
+  exit_code=$?
+  set -e
+
+  end_ms=$(now_ms)
+  total_ms=$((end_ms - start_ms))
+
+  echo "{\"tool\":\"$tool\",\"test\":\"$test_name\",\"run\":$run_number,\"total_ms\":$total_ms,\"exit_code\":$exit_code}"
+}
+
+# ── Run benchmark suite ────────────────────────────
+# Args: tool test_name command...
+run_benchmark() {
+  local tool="$1" test_name="$2"
+  shift 2
+  local cmd=("$@")
+  local outfile="$RESULTS_DIR/${tool}-${test_name}.jsonl"
+
+  # Warm-up (descartada)
+  echo ">>> [$tool] $test_name: warm-up..."
+  run_single "$tool" "$test_name" 0 "${cmd[@]}" > /dev/null || true
+
+  # Reset entre warm-up y mediciones
+  xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+  sleep 1
+
+  # Mediciones
+  echo ">>> [$tool] $test_name: $MEASURED_RUNS runs..."
+  for i in $(seq 1 "$MEASURED_RUNS"); do
+    local result
+    result=$(run_single "$tool" "$test_name" "$i" "${cmd[@]}")
+    echo "$result" >> "$outfile"
+    echo "    run $i: $(echo "$result" | python3 -c "import sys,json; print(json.load(sys.stdin)['total_ms'])")ms"
+
+    # Reset app entre runs
+    xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+    sleep 1
+  done
+}
+
+# ── Verificar herramientas ─────────────────────────
+echo "=== Benchmark: AutoPilot vs Maestro ==="
+echo ""
+
+if ! command -v "$AUTOPILOT_BIN" &>/dev/null && [ ! -x "$AUTOPILOT_BIN" ]; then
+  echo "ERROR: AutoPilot no encontrado en $AUTOPILOT_BIN"
+  exit 1
+fi
+
+if ! command -v "$MAESTRO_BIN" &>/dev/null && [ ! -x "$MAESTRO_BIN" ]; then
+  echo "ERROR: Maestro no encontrado en $MAESTRO_BIN"
+  exit 1
+fi
+
+echo "AutoPilot: $AUTOPILOT_BIN"
+echo "Maestro:   $MAESTRO_BIN"
+echo "Runs:      $MEASURED_RUNS (+ $WARMUP_RUNS warm-up)"
+echo ""
+
+# ── AutoPilot benchmarks ──────────────────────────
+run_benchmark "autopilot" "biometric" "$AUTOPILOT_BIN" run "$SCRIPT_DIR/biometric.auto"
+run_benchmark "autopilot" "login"     "$AUTOPILOT_BIN" run "$SCRIPT_DIR/login.auto"
+
+# ── Maestro benchmarks ────────────────────────────
+run_benchmark "maestro" "biometric" "$MAESTRO_BIN" test "$SCRIPT_DIR/biometric.yaml"
+run_benchmark "maestro" "login"     "$MAESTRO_BIN" test "$SCRIPT_DIR/login.yaml"
+
+# ── Merge ─────────────────────────────────────────
+cat "$RESULTS_DIR"/*.jsonl > "$RESULTS_DIR/all-results.jsonl"
+echo ""
+echo "=== Benchmark completo ==="
+echo "Resultados: $RESULTS_DIR/all-results.jsonl"


### PR DESCRIPTION
## Summary
- Workflow de benchmark continuo que compara AutoPilot vs Maestro en iOS
- 2 tests: biometric (ventaja nativa AutoPilot) + login/navegación (terreno de Maestro)
- 10 runs medidas + 1 warm-up descartada por herramienta/test
- Reporte markdown con min/avg/max/p95 + summary JSON como artifacts

## Archivos
| Archivo | Propósito |
|---------|-----------|
| `benchmark.yml` | Workflow CI (push a main + manual) |
| `biometric.auto` / `biometric.yaml` | Test biometric en ambos formatos |
| `login.auto` / `login.yaml` | Test login/nav en ambos formatos |
| `biometric-helpers.js` | Helper JS para biometric en Maestro (runScript) |
| `run-benchmark.sh` | Runner: timing, JSONL output, warm-up |
| `generate-report.sh` | Genera markdown comparativo + summary.json |

## Honestidad
- Warm-up run para ambos (JVM de Maestro, fair play)
- Test de login/UI donde Maestro es fuerte
- Maestro usa `runScript` para biometric — es lo que haría un usuario real
- Sin screenshots en benchmarks (evitar varianza de I/O)

## Test plan
- [ ] Merge a main y verificar que el workflow corre
- [ ] Verificar reporte en GitHub Step Summary
- [ ] Descargar artifacts (JSONL + markdown + JSON)
- [ ] Validar que ambas herramientas completan las 10 runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)