### PR TITLE
fix: benchmark — simulador iOS 26+

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,17 +52,28 @@ jobs:
           (cd cli && swift build -c release && cp .build/release/auto ../auto) &
           BUILD_PID=$!
 
-          # Boot simulator mientras compila
+          # Boot simulator — necesita iOS 26+ (deployment target de Test Automatitacion)
           DEVICE_UDID=$(xcrun simctl list devices available -j | python3 -c "
-          import json, sys
+          import json, sys, re
           data = json.loads(sys.stdin.read())
+          best = None
+          best_ver = (0, 0)
           for runtime, devices in data['devices'].items():
-            if 'iOS' in runtime:
-              for d in devices:
-                if d['isAvailable'] and 'iPhone' in d['name']:
-                  print(d['udid'])
-                  sys.exit(0)
-          sys.exit(1)
+            m = re.search(r'iOS[- ](\d+)\.(\d+)', runtime)
+            if not m:
+              continue
+            ver = (int(m.group(1)), int(m.group(2)))
+            if ver[0] < 26:
+              continue
+            for d in devices:
+              if d['isAvailable'] and 'iPhone' in d['name']:
+                if ver > best_ver:
+                  best = d['udid']
+                  best_ver = ver
+          if best:
+            print(best)
+          else:
+            sys.exit(1)
           ")
           xcrun simctl boot "$DEVICE_UDID" 2>/dev/null || true
           echo "DEVICE_UDID=$DEVICE_UDID" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- El benchmark falló porque el script seleccionaba un simulador iOS 18.x
- La app Test Automatitacion tiene deployment target iOS 26.0
- Ahora filtra por iOS 26+ y toma la versión más reciente disponible

## Test plan
- [ ] Merge y verificar que el benchmark workflow pasa

🤖 Generated with [Claude Code](https://claude.com/claude-code)