### PR TITLE
fix: .autopilot usa path relativo

### DIFF
--- a/.autopilot
+++ b/.autopilot
@@ -1,4 +1,4 @@
 project=Demo/CameraTestApp/CameraTestApp.xcodeproj
 scheme=CameraTestApp
 bundle=dev.autopilot.test.CameraTestApp
-image=/Users/franciscojaviersaldivarrubio/Documents/AutomationApp/temp/test-image.jpg
+image=scripts/demo-images/foto-1.jpg


### PR DESCRIPTION
## Summary
- Cambia `image=` en `.autopilot` de path absoluto (`/Users/franciscojaviersaldivarrubio/...`) a path relativo (`scripts/demo-images/foto-1.jpg`)
- El path anterior no existia en esta maquina y fallaria en cualquier otra

## Test plan
- [ ] Verificar que `auto config image` lee el path correcto
- [ ] Verificar que camera mock usa la imagen al hacer `auto launch --inject`

🤖 Generated with [Claude Code](https://claude.com/claude-code)