### PR TITLE
fix: editor — filtrar autocomplete por plataforma, scroll, timeout

### DIFF
--- a/editor/src-tauri/src/lib.rs
+++ b/editor/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 use std::process::Command;
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::time::Duration;
 use serde_json::Value;
 
 fn find_binary(name: &str) -> PathBuf {
@@ -291,27 +293,40 @@ fn take_screenshot(bin: &PathBuf) -> String {
 }
 
 /// Captures screenshot + tree in one call — screenshot and tree run in parallel.
+/// Uses a 10-second timeout to prevent the editor from freezing if the CLI hangs.
 #[tauri::command]
 fn inspect(platform: Option<String>) -> Result<Value, String> {
     let plat = platform.as_deref().unwrap_or("ios");
     let bin = auto_binary(plat);
+    let timeout = Duration::from_secs(10);
+
+    // Channels for receiving results with timeout
+    let (screenshot_tx, screenshot_rx) = mpsc::channel::<String>();
+    let (tree_tx, tree_rx) = mpsc::channel::<Result<(Vec<Value>, Vec<String>), String>>();
 
     // Run screenshot and tree in parallel
     let bin_screenshot = bin.clone();
-    let screenshot_thread = std::thread::spawn(move || {
-        take_screenshot(&bin_screenshot)
+    std::thread::spawn(move || {
+        let result = take_screenshot(&bin_screenshot);
+        let _ = screenshot_tx.send(result);
     });
 
     let bin_tree = bin.clone();
-    let tree_thread = std::thread::spawn(move || -> Result<(Vec<Value>, Vec<String>), String> {
-        let stdout = run_cli(&bin_tree, &["tree"])?;
-        Ok(parse_tree_output(&stdout))
+    std::thread::spawn(move || {
+        let result = run_cli(&bin_tree, &["tree"])
+            .map(|stdout| parse_tree_output(&stdout));
+        let _ = tree_tx.send(result);
     });
 
-    // Collect results
-    let image_b64 = screenshot_thread.join().unwrap_or_default();
-    let (elements, labels) = tree_thread.join()
-        .map_err(|_| "Tree thread panicked".to_string())?
+    // Collect results with timeout
+    let image_b64 = screenshot_rx.recv_timeout(timeout)
+        .unwrap_or_else(|_| {
+            eprintln!("inspect: screenshot timed out after 10s");
+            String::new()
+        });
+
+    let (elements, labels) = tree_rx.recv_timeout(timeout)
+        .map_err(|_| "Inspect timeout: tree took longer than 10 seconds. Is the device connected?".to_string())?
         .map_err(|e| format!("Tree failed: {}", e))?;
 
     // Index: for Android, generate from tree; for iOS, call `auto index`

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import Editor, { OnMount } from "@monaco-editor/react";
 import { invoke } from "@tauri-apps/api/core";
 import Inspector from "./Inspector";
@@ -24,7 +24,7 @@ const AUTO_COMMANDS = [
   { label: "exists", detail: "Verificar existencia", insertText: 'exists "${1:element}"' },
   { label: "waitFor", detail: "Esperar elemento", insertText: 'waitFor "${1:element}" ${2:10}' },
   { label: "elementAt", detail: "Elemento en coordenada", insertText: "elementAt ${1:x} ${2:y}" },
-  { label: "index", detail: "Listar elementos con $N (iOS)" },
+  { label: "index", detail: "Listar elementos con $N (iOS)", platform: "ios" as const },
 
   // Interacción
   { label: "tap", detail: "Tap en elemento", insertText: 'tap "${1:element}"' },
@@ -58,14 +58,14 @@ const AUTO_COMMANDS = [
   { label: "biometric status", detail: "Estado biometría" },
 
   // Cámara (iOS)
-  { label: "camera start", detail: "Iniciar camara virtual", insertText: "camera start ${1:image.jpg}" },
-  { label: "camera feed", detail: "Actualizar imagen", insertText: "camera feed ${1:image.jpg}" },
-  { label: "camera stop", detail: "Detener camara" },
-  { label: "camera status", detail: "Estado camara" },
-  { label: "inject", detail: "Cambiar imagen mock", insertText: "inject ${1:image.jpg}" },
+  { label: "camera start", detail: "Iniciar camara virtual", insertText: "camera start ${1:image.jpg}", platform: "ios" as const },
+  { label: "camera feed", detail: "Actualizar imagen", insertText: "camera feed ${1:image.jpg}", platform: "ios" as const },
+  { label: "camera stop", detail: "Detener camara", platform: "ios" as const },
+  { label: "camera status", detail: "Estado camara", platform: "ios" as const },
+  { label: "inject", detail: "Cambiar imagen mock", insertText: "inject ${1:image.jpg}", platform: "ios" as const },
 
   // Build (iOS)
-  { label: "build", detail: "Compilar con mock", insertText: "build -project ${1:App.xcodeproj} -scheme ${2:App}" },
+  { label: "build", detail: "Compilar con mock", insertText: "build -project ${1:App.xcodeproj} -scheme ${2:App}", platform: "ios" as const },
 
   // Media y datos
   { label: "media", detail: "Inyectar foto a galeria", insertText: "media ${1:photo.jpg}" },
@@ -105,6 +105,9 @@ function App() {
   const abortRef = useRef(false);
   const indexedRef = useRef<any[]>([]);
   const labelsRef = useRef<string[]>([]);
+  const platformRef = useRef<"ios" | "android">(platform);
+
+  useEffect(() => { platformRef.current = platform; }, [platform]);
 
   const appendOutput = useCallback((text: string) => {
     setOutput((prev) => prev + text + "\n");
@@ -184,8 +187,10 @@ function App() {
         const currentIndexed = indexedRef.current;
         const suggestions: any[] = [];
 
-        // 1. Commands
+        // 1. Commands (filtered by platform)
+        const currentPlatform = platformRef.current;
         for (const cmd of AUTO_COMMANDS) {
+          if (cmd.platform && cmd.platform !== currentPlatform) continue;
           suggestions.push({
             label: cmd.label,
             kind: monaco.languages.CompletionItemKind.Function,

--- a/editor/src/Inspector.tsx
+++ b/editor/src/Inspector.tsx
@@ -26,6 +26,7 @@ function makeActions(label: string, suffix: string) {
     { label: "longPress", icon: "✊", cmd: `longPress ${ref} 1` },
     { label: "type", icon: "⌨️", cmd: `type ${ref} "text"` },
     { label: "clear", icon: "🗑", cmd: `clear ${ref}` },
+    { label: "scroll", icon: "📜", cmd: `scroll ${ref} down` },
     { label: "waitFor", icon: "⏳", cmd: `waitFor ${ref} 10` },
     { label: "exists", icon: "❓", cmd: `exists ${ref}` },
   ];


### PR DESCRIPTION
## Summary
- **Autocomplete por plataforma**: comandos iOS-only (camera, inject, build, index) ya no aparecen en modo Android. Se usa `platformRef` para mantener estado actualizado en el closure de Monaco.
- **Accion scroll en Inspector**: nueva accion `scroll <ref> down` en la barra de acciones del Inspector.
- **Timeout en inspect (Rust)**: el comando `inspect` ahora usa `mpsc::recv_timeout(10s)` en vez de `.join()`. Si el CLI se cuelga (dispositivo desconectado), el editor muestra error en vez de congelarse.

## Test plan
- [x] Abrir editor, seleccionar Android → verificar que `camera start`, `inject`, `build`, `index` NO aparecen en autocomplete
- [x] Cambiar a iOS → verificar que todos los comandos aparecen
- [x] Hacer Inspect → seleccionar un elemento → verificar que aparece el boton scroll
- [x] Desconectar dispositivo → hacer Inspect → verificar que muestra error de timeout despues de 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)