### PR TITLE
feat: Android CLI parity — index, inspect, Label[2], env vars

### DIFF
--- a/cli/Sources/AutoCore/AdbLegacyBridge.swift
+++ b/cli/Sources/AutoCore/AdbLegacyBridge.swift
@@ -367,8 +367,18 @@ public final class AdbLegacyBridge: DeviceBridge {
     // MARK: - DeviceBridge: App Lifecycle
 
     public func launchApp(bundleId: String, envVars: [String: String]) throws {
-        // Use monkey to launch the default launcher activity
-        try runAdb(["shell", "monkey", "-p", bundleId, "-c", "android.intent.category.LAUNCHER", "1"])
+        // Use am start for proper intent launching with env var support
+        var cmdArgs = ["shell", "am", "start",
+                       "-a", "android.intent.action.MAIN",
+                       "-c", "android.intent.category.LAUNCHER",
+                       bundleId]
+
+        // Pass environment variables as intent string extras with AUTOPILOT_ prefix
+        for (key, value) in envVars.sorted(by: { $0.key < $1.key }) {
+            cmdArgs.append(contentsOf: ["--es", "AUTOPILOT_\(key)", value])
+        }
+
+        try runAdb(cmdArgs)
     }
 
     public func terminateApp(bundleId: String) throws {

--- a/cli/Sources/AutoCore/ElementIndexShared.swift
+++ b/cli/Sources/AutoCore/ElementIndexShared.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Platform-agnostic element indexer that works with JSON tree data
+/// (the format returned by DeviceBridge.tree()).
+/// Assigns sequential $N indices to interactive/labeled elements,
+/// filtering out generic containers without useful info.
+public final class ElementIndexShared {
+
+    public struct Entry {
+        public let index: Int
+        public let role: String
+        public let label: String
+        public let id: String
+        public let frame: String
+    }
+
+    private var entries: [Entry] = []
+
+    public init() {}
+
+    /// Generic container roles that get filtered when they have no label.
+    private static let containerRoles: Set<String> = [
+        "FrameLayout", "LinearLayout", "ViewGroup", "RelativeLayout",
+        "ConstraintLayout", "CoordinatorLayout", "ScrollView",
+        "HorizontalScrollView", "RecyclerView", "ListView",
+        "android.view.View", "View"
+    ]
+
+    /// Interactive roles that are always indexed (even without label, if they have *some* identifier).
+    private static let interactiveRoles: Set<String> = [
+        "Button", "EditText", "CheckBox", "Switch", "SeekBar",
+        "ImageButton", "ToggleButton", "RadioButton", "Spinner",
+        "android.widget.Button", "android.widget.EditText",
+        "android.widget.CheckBox", "android.widget.Switch",
+        "android.widget.SeekBar", "android.widget.ImageButton",
+        "android.widget.ToggleButton", "android.widget.RadioButton",
+        "android.widget.Spinner"
+    ]
+
+    /// Labeled static roles that get indexed when they have a label.
+    private static let labeledStaticRoles: Set<String> = [
+        "TextView", "ImageView", "android.widget.TextView",
+        "android.widget.ImageView"
+    ]
+
+    /// Build the index from a tree returned by DeviceBridge.tree().
+    public func build(from tree: [[String: Any]]) {
+        entries = []
+        for element in tree {
+            indexElement(element, depth: 0)
+        }
+    }
+
+    private func indexElement(_ element: [String: Any], depth: Int) {
+        guard depth < 30 else { return }
+
+        let role = element["role"] as? String ?? ""
+        let title = element["title"] as? String ?? ""
+        let label = element["label"] as? String ?? ""
+        let identifier = element["identifier"] as? String ?? ""
+        let display = element["display"] as? String ?? ""
+
+        // Determine the effective label (best human-readable text)
+        let effectiveLabel: String = {
+            if !title.isEmpty { return title }
+            if !label.isEmpty { return label }
+            if !display.isEmpty && display != role { return display }
+            return ""
+        }()
+
+        let effectiveId = identifier
+
+        // Determine the short role name (strip package prefix)
+        let shortRole: String = {
+            if let dot = role.lastIndex(of: ".") {
+                return String(role[role.index(after: dot)...])
+            }
+            return role
+        }()
+
+        let isInteractive = Self.interactiveRoles.contains(role) || Self.interactiveRoles.contains(shortRole)
+        let isLabeledStatic = Self.labeledStaticRoles.contains(role) || Self.labeledStaticRoles.contains(shortRole)
+        let isContainer = Self.containerRoles.contains(role) || Self.containerRoles.contains(shortRole)
+        let hasLabel = !effectiveLabel.isEmpty || !effectiveId.isEmpty
+
+        // Index logic:
+        // - Interactive elements: always index if they have any identifier
+        // - Labeled static elements: index if they have a label
+        // - Containers without labels: skip
+        let shouldIndex: Bool
+        if isInteractive && hasLabel {
+            shouldIndex = true
+        } else if isLabeledStatic && hasLabel {
+            shouldIndex = true
+        } else if !isContainer && hasLabel {
+            // Unknown role but has a label — index it
+            shouldIndex = true
+        } else {
+            shouldIndex = false
+        }
+
+        if shouldIndex {
+            // Build frame string
+            var frameStr = ""
+            if let frame = element["frame"] as? [String: Any] {
+                let x = frame["x"] ?? 0
+                let y = frame["y"] ?? 0
+                let w = frame["width"] ?? 0
+                let h = frame["height"] ?? 0
+                frameStr = "[\(x),\(y) \(w)x\(h)]"
+            } else if let frame = element["frame"] as? String, !frame.isEmpty {
+                frameStr = frame
+            }
+
+            entries.append(Entry(
+                index: entries.count,
+                role: shortRole,
+                label: effectiveLabel,
+                id: effectiveId,
+                frame: frameStr
+            ))
+        }
+
+        // Recurse into children
+        if let children = element["children"] as? [[String: Any]] {
+            for child in children {
+                indexElement(child, depth: depth + 1)
+            }
+        }
+    }
+
+    /// Get element by index.
+    public func get(_ index: Int) -> Entry? {
+        guard index >= 0 && index < entries.count else { return nil }
+        return entries[index]
+    }
+
+    /// All entries.
+    public var all: [Entry] { entries }
+
+    /// Count of indexed elements.
+    public var count: Int { entries.count }
+
+    /// Find entries matching a label/id (case-insensitive substring).
+    public func find(_ query: String) -> [Entry] {
+        let q = query.lowercased()
+        return entries.filter {
+            $0.label.lowercased().contains(q) ||
+            $0.id.lowercased().contains(q)
+        }
+    }
+
+    /// Print the index as a formatted table.
+    public func printIndex() {
+        for entry in entries {
+            let idx = "$\(entry.index)".padding(toLength: 5, withPad: " ", startingAt: 0)
+            let role = entry.role.padding(toLength: 14, withPad: " ", startingAt: 0)
+            let label = entry.label.isEmpty ? entry.id : entry.label
+            let display = label.isEmpty ? "(no label)" : "\"\(label)\""
+            print("\(idx) \(role) \(display.padding(toLength: 30, withPad: " ", startingAt: 0)) \(entry.frame)")
+        }
+        print("\n\(entries.count) element(s) indexed")
+    }
+}

--- a/cli/Sources/AutoCore/TargetResolverShared.swift
+++ b/cli/Sources/AutoCore/TargetResolverShared.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Platform-agnostic target resolver for Label[N] and $N syntax.
+/// Pure string parsing — no AX or platform dependencies.
+public struct TargetResolverShared {
+
+    /// Parse a target string into label and optional occurrence index.
+    /// "Camera[2]" → ("Camera", 2)
+    /// "Camera"    → ("Camera", nil)
+    /// "$5"        → ("$5", nil) — caller handles $N separately
+    public static func parse(_ target: String) -> (label: String, index: Int?) {
+        // Check for [N] suffix
+        if let bracket = target.lastIndex(of: "["),
+           let end = target.lastIndex(of: "]"),
+           bracket < end {
+            let label = String(target[target.startIndex..<bracket])
+            let numStr = String(target[target.index(after: bracket)..<end])
+            if let n = Int(numStr) {
+                return (label, n)
+            }
+        }
+        return (target, nil)
+    }
+
+    /// Check if a target is a $N index reference.
+    /// Returns the index number if it is, nil otherwise.
+    public static func parseIndex(_ target: String) -> Int? {
+        guard target.hasPrefix("$"),
+              let n = Int(target.dropFirst()) else { return nil }
+        return n
+    }
+
+    /// Search a tree (from DeviceBridge.tree()) for all elements matching a label.
+    /// Returns matches with their 1-based occurrence number.
+    public static func findAll(in tree: [[String: Any]], matching label: String) -> [(element: [String: Any], occurrence: Int)] {
+        var results: [(element: [String: Any], occurrence: Int)] = []
+        var count = 0
+        let query = label.lowercased()
+        findRecursive(elements: tree, query: query, results: &results, count: &count)
+        return results
+    }
+
+    private static func findRecursive(elements: [[String: Any]], query: String, results: inout [(element: [String: Any], occurrence: Int)], count: inout Int) {
+        for element in elements {
+            let title = (element["title"] as? String ?? "").lowercased()
+            let label = (element["label"] as? String ?? "").lowercased()
+            let identifier = (element["identifier"] as? String ?? "").lowercased()
+            let display = (element["display"] as? String ?? "").lowercased()
+
+            let matches = title.contains(query) ||
+                         label.contains(query) ||
+                         identifier.contains(query) ||
+                         display.contains(query) ||
+                         title == query ||
+                         label == query
+
+            if matches {
+                count += 1
+                results.append((element: element, occurrence: count))
+            }
+
+            if let children = element["children"] as? [[String: Any]] {
+                findRecursive(elements: children, query: query, results: &results, count: &count)
+            }
+        }
+    }
+}

--- a/cli/Sources/CLIAndroid/main.swift
+++ b/cli/Sources/CLIAndroid/main.swift
@@ -59,6 +59,112 @@ func executeCommand(_ args: [String]) throws {
         let ms = elapsedMs(start)
         print("Connected to \(deviceId) (\(ms)ms)")
 
+    case "index":
+        let tree = try bridge.tree()
+        let index = ElementIndexShared()
+        index.build(from: tree)
+        if args.count >= 2 {
+            let results = index.find(args[1])
+            if results.isEmpty {
+                print("No elements matching '\(args[1])'")
+            } else {
+                for entry in results {
+                    let idx = "$\(entry.index)".padding(toLength: 5, withPad: " ", startingAt: 0)
+                    let role = entry.role.padding(toLength: 14, withPad: " ", startingAt: 0)
+                    let label = entry.label.isEmpty ? entry.id : entry.label
+                    let display = label.isEmpty ? "(no label)" : "\"\(label)\""
+                    print("\(idx) \(role) \(display.padding(toLength: 30, withPad: " ", startingAt: 0)) \(entry.frame)")
+                }
+                print("\n\(results.count) match(es)")
+            }
+        } else {
+            index.printIndex()
+        }
+        let ms = elapsedMs(start)
+        print("(\(ms)ms)")
+
+    case "inspect":
+        guard args.count >= 2 else {
+            print("Usage: auto-android inspect <query>")
+            return
+        }
+        let query = args[1].lowercased()
+        let tree = try bridge.tree()
+        var found = 0
+        func inspectNode(_ node: [String: Any], depth: Int) {
+            guard depth < 20 else { return }
+            let title = (node["title"] as? String) ?? ""
+            let label = (node["label"] as? String) ?? ""
+            let identifier = (node["identifier"] as? String) ?? ""
+            let matches = title.lowercased().contains(query) ||
+                         label.lowercased().contains(query) ||
+                         identifier.lowercased().contains(query)
+            if matches {
+                found += 1
+                print("--- Match \(found) ---")
+                for key in node.keys.sorted() {
+                    if key == "children" {
+                        let children = node[key] as? [[String: Any]] ?? []
+                        print("  \(key): \(children.count) child(ren)")
+                    } else {
+                        print("  \(key): \(node[key] ?? "nil")")
+                    }
+                }
+                print()
+            }
+            if let children = node["children"] as? [[String: Any]] {
+                for child in children { inspectNode(child, depth: depth + 1) }
+            }
+        }
+        for node in tree { inspectNode(node, depth: 0) }
+        if found == 0 { print("No elements matching '\(args[1])'") }
+        else { print("\(found) match(es) (\(elapsedMs(start))ms)") }
+
+    case "tap":
+        guard args.count >= 2 else {
+            print("Usage: auto-android tap <label|$N|label[N]>")
+            return
+        }
+        let target = args.dropFirst().joined(separator: " ")
+
+        // $N index reference
+        if let idx = TargetResolverShared.parseIndex(target) {
+            let tree = try bridge.tree()
+            let index = ElementIndexShared()
+            index.build(from: tree)
+            guard let entry = index.get(idx) else {
+                print("Index $\(idx) not found (max $\(index.count - 1))")
+                return
+            }
+            // Tap by label through bridge
+            let tapTarget = entry.label.isEmpty ? entry.id : entry.label
+            try bridge.tap(target: tapTarget)
+            print("Tapped $\(idx) '\(tapTarget)' (\(elapsedMs(start))ms)")
+            return
+        }
+
+        // Label[N] occurrence syntax
+        let (label, occurrence) = TargetResolverShared.parse(target)
+        if let occ = occurrence {
+            let tree = try bridge.tree()
+            let matches = TargetResolverShared.findAll(in: tree, matching: label)
+            guard let match = matches.first(where: { $0.occurrence == occ }) else {
+                print("'\(label)[\(occ)]' not found (\(matches.count) occurrence(s) total)")
+                return
+            }
+            let tapLabel = (match.element["title"] as? String) ?? (match.element["label"] as? String) ?? label
+            try bridge.tap(target: tapLabel)
+            print("Tapped '\(label)[\(occ)]' (\(elapsedMs(start))ms)")
+            return
+        }
+
+        // Plain label — delegate to shared
+        let handled = try executeSharedCommand(args, bridge: bridge)
+        if !handled {
+            print("Unknown command: \(cmd)")
+        }
+        return
+
     case "launch":
         let config = AutoPilotConfig.readAll()
         let bundleId: String
@@ -101,8 +207,10 @@ func printUsage() {
       ping                              Check ADB connection
       tree                              Print accessibility tree
       tree -s "query"                   Search elements
+      index [query]                     List indexed elements ($N syntax)
+      inspect <query>                   Deep element inspection
       launch <package>                  Launch app
-      tap <text|desc|id>                Tap element
+      tap <label|$N|label[N]>           Tap element (supports $N and Label[2])
       longPress <text|desc|id> [secs]   Long press element
       doubleTap <text|desc|id>          Double tap element
       clear <text|desc|id>              Clear text field


### PR DESCRIPTION
## Summary
- `auto-android index [query]` — indexacion de elementos con sintaxis `$N`
- `auto-android inspect <query>` — inspeccion profunda de atributos de elementos
- `auto-android tap $N|Label[2]` — soporte de indices y resolucion de duplicados
- `launchApp` usa `am start` con `--es` para environment variables (antes usaba `monkey`)
- Dos nuevos modulos compartidos en AutoCore: `ElementIndexShared.swift` y `TargetResolverShared.swift`

## Test plan
- [ ] `auto-android index` lista elementos del emulador
- [ ] `auto-android index "Login"` filtra por query
- [ ] `auto-android inspect "Login"` muestra todos los atributos
- [ ] `auto-android tap $0` hace tap por indice
- [ ] `auto-android tap "Login[2]"` hace tap en el segundo duplicado
- [ ] `swift build` compila sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)