### PR TITLE
docs: referencia de comandos y tutorial de scripts .auto

### DIFF
--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -41,13 +41,19 @@ docs/
 ├── 05-el-editor.md              ← De CLI a IDE visual
 ├── 06-alternativas.md           ← Landscape honesto
 ├── 07-decisiones.md             ← ADRs: por qué Swift, por qué AX públicas
+├── 08-por-que-es-libre.md       ← La deuda con el open source
+├── 09-el-agente-android.md      ← De 2100ms a 75ms con agente nativo
+├── 10-paridad-android.md        ← (placeholder, se escribirá después de implementar paridad)
 ├── apendices/
-│   ├── comandos.md              ← Referencia CLI
+│   ├── comandos.md              ← Referencia CLI (~30 comandos, agrupados por categoría)
+│   ├── scripts.md               ← Guía de scripts .auto (sintaxis, patrones, errores)
 │   ├── variables-entorno.md     ← Inyección de datos
 │   ├── ci-cd.md                 ← GitHub Actions
 │   └── troubleshooting.md       ← Errores comunes
 └── roadmap.md                   ← Futuro
 ```
+
+> **Mantenimiento:** Cuando se agregan comandos nuevos al CLI, actualizar `apendices/comandos.md`. Cuando se cambia la sintaxis del parser, actualizar `apendices/scripts.md`.
 
 ## Reglas de distribución
 

--- a/docs/libro/README.md
+++ b/docs/libro/README.md
@@ -28,13 +28,15 @@ Documentamos todo el proceso — los errores, los callejones sin salida, las dec
 7. **[Decisiones](07-decisiones.md)** — ADRs 1-8: Swift puro, AX públicas, no YAML, dos binarios + DeviceBridge
 8. **[Por qué es libre](08-por-que-es-libre.md)** — La deuda con el open source, el problema de la IA privatizada, y por qué documentamos los fracasos
 9. **[El agente Android](09-el-agente-android.md)** — De 2100ms a 75ms: un APK de instrumentación que habla directo con UiAutomation
+10. **Paridad Android** *(pendiente)* — Se escribira despues de implementar paridad completa iOS/Android
 
 ### Apendices
 
-- **[Referencia de comandos](apendices/comandos.md)** — Los ~30 comandos del CLI
-- **[Variables de entorno](apendices/variables-entorno.md)** — Inyección de datos para CI/CD
-- **[CI/CD](apendices/ci-cd.md)** — GitHub Actions, permisos TCC, configuración de runners
-- **[Troubleshooting](apendices/troubleshooting.md)** — Errores comúnes y como resolverlos
+- **[Referencia de comandos](apendices/comandos.md)** — Los ~30 comandos del CLI, agrupados por categoria
+- **[Guia de scripts .auto](apendices/scripts.md)** — Sintaxis, patrones, buenas practicas y errores comunes
+- **[Variables de entorno](apendices/variables-entorno.md)** — Inyeccion de datos para CI/CD
+- **[CI/CD](apendices/ci-cd.md)** — GitHub Actions, permisos TCC, configuracion de runners
+- **[Troubleshooting](apendices/troubleshooting.md)** — Errores comunes y como resolverlos
 
 ### Referencia
 

--- a/docs/libro/apendices/comandos.md
+++ b/docs/libro/apendices/comandos.md
@@ -1,0 +1,132 @@
+# Apendice A — Referencia de Comandos
+
+AutoPilot expone dos binarios: `auto` (iOS) y `auto-android` (Android). Ambos comparten la mayoria de comandos a traves de `CommandDispatcher`, un dispatcher central que recibe cualquier `DeviceBridge` y ejecuta la misma logica. Los comandos que dependen de APIs de plataforma (AXUIElement en iOS, adb/agente en Android) viven en sus respectivos `main.swift`.
+
+La regla es simple: si el comando funciona igual en ambas plataformas, esta en el dispatcher compartido. Si necesita algo especifico del dispositivo, esta en el binario correspondiente.
+
+---
+
+## Conexion
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `ping` | `auto ping` | iOS | Verifica que Simulator.app esta corriendo y accesible via AX | `auto ping` |
+| `ping` | `auto-android ping` | Android | Verifica conexion ADB y devuelve el device ID | `auto-android ping` |
+| `list` | `auto list` | Ambas | Lista dispositivos disponibles (booted y shutdown) con nombre, OS y UDID | `auto list` |
+
+## Arbol y busqueda
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `tree` | `auto tree` | Ambas | Imprime el arbol de accesibilidad completo del dispositivo activo | `auto tree` |
+| `tree -s` | `auto tree -s "query"` | Ambas | Busca elementos en el arbol que coincidan con el query | `auto tree -s "Login"` |
+| `index` | `auto index [query]` | iOS | Construye un indice numerico de todos los elementos. Permite buscar y despues hacer tap por `$N` | `auto index "Camera"` |
+| `exists` | `auto exists <label>` | Ambas | Verifica si un elemento existe en el arbol. Imprime YES o NO | `auto exists "Submit"` |
+| `elementAt` | `auto elementAt <x> <y>` | Ambas | Devuelve el elemento en las coordenadas especificadas | `auto elementAt 200 400` |
+| `inspect` | `auto inspect <query>` | iOS | Debug profundo: dump de atributos AX del elemento. Util cuando `tree -s` no encuentra algo que deberia estar ahi | `auto inspect "NavigationBar"` |
+
+## Interaccion
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `tap` | `auto tap <label>` | Ambas | Tap en un elemento por identifier, title o label. Soporta multi-tap con comas | `auto tap "Sign In"` |
+| `tap` (con indice) | `auto tap $N` | iOS | Tap por indice numerico del `index`. Reconstruye el indice si no existe | `auto tap $5` |
+| `tap` (con ocurrencia) | `auto tap Label[N]` | iOS | Tap en la N-esima ocurrencia de un label duplicado | `auto tap Camera[2]` |
+| `tap` (multiples) | `auto tap a,b,c` | Ambas | Taps secuenciales en multiples elementos separados por coma | `auto tap 1,2,3,4` |
+| `tapAt` | `auto tapAt <x> <y>` | Ambas | Tap en coordenadas absolutas (no busca elemento) | `auto tapAt 150 300` |
+| `doubleTap` | `auto doubleTap <label>` | Ambas | Doble tap en un elemento | `auto doubleTap "Image"` |
+| `longPress` | `auto longPress <label> [secs]` | Ambas | Presion larga. Default 1 segundo | `auto longPress "Delete" 2` |
+| `type` | `auto type <text>` | Ambas | Escribe texto en el campo enfocado | `auto type "user@test.com"` |
+| `type` (con target) | `auto type <target> <text>` | Ambas | Hace tap en el target y luego escribe el texto | `auto type "Email" "user@test.com"` |
+| `clear` | `auto clear <label>` | Ambas | Limpia el contenido de un campo de texto | `auto clear "Username"` |
+| `scroll` | `auto scroll <label> <dir>` | Ambas | Scroll en un elemento. Direcciones: up, down, left, right | `auto scroll "List" down` |
+| `swipe` | `auto swipe <dir>` | Ambas | Swipe global. Direcciones: up, down, left, right | `auto swipe up` |
+| `waitFor` | `auto waitFor <label> [timeout]` | Ambas | Espera hasta que un elemento aparezca. Polling cada 500ms. Default 10s. Sale con exit(1) si timeout | `auto waitFor "Welcome" 15` |
+| `wait` / `sleep` | `auto wait <secs>` | Ambas | Pausa la ejecucion N segundos. Default 1s | `auto wait 2` |
+
+## App
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `launch` | `auto launch <bundleId> [flags]` | iOS | Lanza app. Soporta `--inject <img>` para camera mock, `--env KEY=VALUE`, `--recompile`. Lee config de `.autopilot` si no se pasa bundleId | `auto launch com.example.app --inject foto.jpg` |
+| `launch` | `auto-android launch <package>` | Android | Lanza app. Lee bundleId de `.autopilot` si no se pasa | `auto-android launch dev.autopilot.test.Explorea` |
+| `terminate` | `auto terminate <bundleId>` | Ambas | Termina (kill) la app | `auto terminate com.example.app` |
+| `install` | `auto install <path>` | Ambas | Instala app en el dispositivo (.app en iOS, .apk en Android) | `auto install build/App.app` |
+
+## Dispositivo
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `boot` | `auto boot <name\|udid>` | Ambas | Enciende un dispositivo por nombre o UDID | `auto boot "iPhone 15"` |
+| `shutdown` | `auto shutdown <name\|udid>` | Ambas | Apaga un dispositivo | `auto shutdown "iPhone 15"` |
+| `openurl` | `auto openurl <url>` | Ambas | Abre una URL en el dispositivo | `auto openurl "https://example.com"` |
+
+## Media y clipboard
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `screenshot` | `auto screenshot [file.png]` | Ambas | Captura screenshot. Default: `screenshot.png` | `auto screenshot result.png` |
+| `media` | `auto media <img> [img2 ...]` | Ambas | Inyecta imagenes al dispositivo (Camera Roll en iOS) | `auto media foto1.jpg foto2.jpg` |
+| `paste` (write) | `auto paste <text>` | Ambas | Escribe texto en el pasteboard/clipboard del dispositivo | `auto paste "texto copiado"` |
+| `paste` (read) | `auto paste` | Ambas* | Lee el contenido del pasteboard. *En Android solo funciona write via ADB | `auto paste` |
+
+> **Nota Android:** La lectura del clipboard no esta soportada via ADB. `auto-android paste` (sin argumentos) puede fallar. Solo la escritura funciona como workaround.
+
+## Biometria
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `biometric enroll` | `auto biometric enroll` | Ambas | Activa Face ID / fingerprint en el dispositivo | `auto biometric enroll` |
+| `biometric unenroll` | `auto biometric unenroll` | Ambas | Desactiva biometria | `auto biometric unenroll` |
+| `biometric match` | `auto biometric match` | Ambas | Envia una autenticacion biometrica exitosa | `auto biometric match` |
+| `biometric fail` | `auto biometric fail` | Ambas | Envia un fallo de autenticacion biometrica | `auto biometric fail` |
+| `biometric status` | `auto biometric status` | Ambas | Verifica si la biometria esta enrolled (YES/NO) | `auto biometric status` |
+
+> Alias: `faceid` funciona como sinonimo de `biometric` en ambas plataformas.
+
+## Camera (iOS)
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `camera start` | `auto camera start <img>` | iOS | Inicia el feed virtual de camara con la imagen dada | `auto camera start foto.jpg` |
+| `camera feed` | `auto camera feed <img>` | iOS | Actualiza la imagen del feed de camara en caliente | `auto camera feed foto2.jpg` |
+| `camera stop` | `auto camera stop` | iOS | Detiene el feed virtual de camara | `auto camera stop` |
+| `camera status` | `auto camera status` | iOS | Muestra si la camara virtual esta activa y que imagen usa | `auto camera status` |
+| `inject` | `auto inject <img>` | iOS | Cambia la imagen de la camara mock sin relanzar la app | `auto inject nueva-foto.jpg` |
+
+> **Nota:** La camara virtual en Android aun no esta implementada. Ver [Capitulo 3](../03-la-camara-virtual.md) para el contexto tecnico.
+
+## Build (iOS)
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `build` | `auto build` | iOS | Compila con camera mock usando la configuracion de `.autopilot` (project, scheme, device) | `auto build` |
+| `build` (explicito) | `auto build <xcodebuild args>` | iOS | Compila pasando argumentos directamente a xcodebuild | `auto build -project App.xcodeproj -scheme App` |
+
+## Configuracion
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `config` | `auto config` | Ambas | Muestra toda la configuracion del archivo `.autopilot` | `auto config` |
+| `config` (get) | `auto config <key>` | Ambas | Lee un valor de configuracion | `auto config bundle` |
+| `config` (set) | `auto config <key> <value>` | Ambas | Establece un valor de configuracion | `auto config project App.xcodeproj` |
+
+Claves de configuracion comunes: `project`, `scheme`, `bundle`, `device`, `image`.
+
+## Script
+
+| Comando | Sintaxis | Plataforma | Descripcion | Ejemplo |
+|---------|----------|------------|-------------|---------|
+| `run` | `auto run <script.auto>` | Ambas | Ejecuta un script `.auto` linea por linea. En iOS incluye auto-wait (UIStabilizer) entre pasos | `auto run login-flow.auto` |
+
+---
+
+## Resumen de plataforma
+
+Comandos **solo iOS**: `ping` (via AX), `index`, `tap $N`, `tap Label[N]`, `inspect`, `launch --inject`, `camera *`, `inject`, `build`.
+
+Comandos **solo Android**: `ping` (via ADB), `launch` (simplificado, sin inject).
+
+Comandos **compartidos** (CommandDispatcher): `tree`, `tree -s`, `tap`, `longPress`, `doubleTap`, `clear`, `type`, `scroll`, `swipe`, `screenshot`, `exists`, `elementAt`, `tapAt`, `media`, `paste`, `boot`, `shutdown`, `install`, `list`, `openurl`, `waitFor`, `wait`/`sleep`, `terminate`, `config`, `biometric`/`faceid`.
+
+> El flag `--legacy` en `auto-android` cambia el bridge de `AgentBridge` (socket TCP, rapido) a `AdbLegacyBridge` (adb shell + uiautomator dump, lento). Se usa para benchmarks comparativos. Ver [Capitulo 9](../09-el-agente-android.md).

--- a/docs/libro/apendices/scripts.md
+++ b/docs/libro/apendices/scripts.md
@@ -1,0 +1,292 @@
+# Apendice B — Guia de Scripts .auto
+
+Los scripts `.auto` son la forma principal de automatizar flujos con AutoPilot. Un archivo `.auto` es una secuencia de comandos — uno por linea — que se ejecutan en orden. Sin YAML, sin JSON, sin XML. Una linea = un comando.
+
+La idea detras del formato es que sea tan simple que puedas escribirlo a mano en 30 segundos. Si necesitas condicionales, bucles o logica compleja, probablemente necesitas un lenguaje de programacion real — y AutoPilot no pretende ser uno.
+
+---
+
+## Sintaxis basica
+
+### Estructura de un script
+
+```bash
+# Esto es un comentario — se ignora
+# Lineas vacias tambien se ignoran
+
+comando argumento1 argumento2
+otro_comando "argumento con espacios"
+```
+
+Reglas:
+- **Una linea, un comando.** No hay forma de partir un comando en varias lineas.
+- **Comentarios** con `#` al inicio de la linea (despues de trim de espacios).
+- **Lineas vacias** se ignoran silenciosamente.
+- Los comandos son exactamente los mismos que usarias en la terminal (ver [Apendice A](comandos.md)).
+
+### Quoting
+
+El parser respeta comillas simples y dobles para agrupar argumentos:
+
+```bash
+# Sin comillas: "tap" recibe "Sign" como argumento (no lo que queremos)
+tap Sign In
+
+# Con comillas: "tap" recibe "Sign In" como un solo argumento
+tap "Sign In"
+
+# Comillas simples tambien funcionan
+type 'Hello World'
+
+# Para elementos sin espacios, no necesitas comillas
+tap Submit
+```
+
+Internamente, `tokenize()` recorre la linea caracter por caracter: cuando encuentra una comilla, agrupa todo hasta la comilla de cierre como un solo token. Fuera de comillas, los espacios separan tokens.
+
+**Advertencia:** No hay soporte para comillas escapadas dentro de comillas (e.g., `"texto con \"comillas\""` no funciona). Si necesitas comillas literales en un texto, usa el otro tipo de comilla: `'texto con "comillas"'`.
+
+---
+
+## Ejecucion
+
+### iOS
+
+```bash
+auto run scripts/examples/login-flow.auto
+```
+
+En iOS, el runner tiene un `UIStabilizer` integrado: antes de cada paso, espera a que la UI se estabilice (0.3s sin cambios en el arbol AX, timeout 3s). Esto significa que rara vez necesitas `wait` explicitos entre comandos.
+
+### Android
+
+```bash
+auto-android run scripts/examples/android-login.auto
+```
+
+En Android no hay UIStabilizer (el agente nativo responde cuando la UI esta lista), asi que los comandos se ejecutan uno tras otro. Si la UI tarda en cargar, necesitas `waitFor` explicitos.
+
+### Cross-platform
+
+La promesa de AutoPilot es que **el mismo script funciona en ambas plataformas**. Cambias el binario, no el script:
+
+```bash
+# iOS
+auto run scripts/examples/login.auto
+
+# Android — mismo archivo
+auto-android run scripts/examples/login.auto
+```
+
+Esto funciona porque ambos binarios implementan el protocolo `DeviceBridge` con los mismos 22 metodos. `tap`, `waitFor`, `screenshot`, `swipe` — todos se comportan igual.
+
+**Limitacion:** Los comandos que solo existen en una plataforma (`camera`, `inject`, `build`, `index`, `inspect`) haran que el script falle en la otra. Si tu flujo necesita esos comandos, mantenlo como script especifico de plataforma.
+
+---
+
+## Patrones y buenas practicas
+
+### 1. Siempre `waitFor` antes de interactuar
+
+```bash
+# MAL — tap puede fallar si la pantalla no ha cargado
+launch com.example.app
+tap "Login"
+
+# BIEN — esperar a que el elemento exista
+launch com.example.app
+waitFor "Login" 10
+tap "Login"
+```
+
+El `waitFor` hace polling cada 500ms hasta que encuentra el elemento o se acaba el timeout. Si el timeout se cumple, el script termina con `exit(1)`.
+
+### 2. Screenshot como evidencia
+
+```bash
+waitFor "Welcome" 10
+screenshot /tmp/01-welcome.png
+
+tap "Profile"
+waitFor "Settings" 5
+screenshot /tmp/02-profile.png
+```
+
+Nombra los screenshots con un prefijo numerico para que se ordenen cronologicamente. Esto es especialmente util en CI/CD donde no puedes ver la pantalla.
+
+### 3. Prefijo numerico para screenshots
+
+Un patron que usamos en todos los scripts de produccion:
+
+```bash
+screenshot /tmp/01-auth-screen.png
+screenshot /tmp/02-pin-entered.png
+screenshot /tmp/03-home.png
+screenshot /tmp/04-filtered.png
+```
+
+En CI, estos screenshots se suben como artefactos y puedes reconstruir visualmente que paso en cada paso.
+
+### 4. `wait` para estabilizar UI
+
+```bash
+biometric enroll
+wait 1
+launch com.example.app
+wait 1
+waitFor "Unlock with Face ID" 10
+```
+
+Algunos comandos (como `biometric enroll`) cambian estado del dispositivo pero la UI no se actualiza instantaneamente. Un `wait 1` da tiempo al sistema.
+
+### 5. `terminate` antes de `launch` para estado limpio
+
+```bash
+# Asegurar que la app no tiene estado residual
+terminate com.example.app
+wait 1
+launch com.example.app
+waitFor "Login" 10
+```
+
+---
+
+## Ejemplo completo: flujo de login
+
+Este script autentica a un usuario en una app que tiene pantalla de login con PIN. Funciona en iOS y Android.
+
+```bash
+# login.auto
+# Flujo: launch → PIN auth → verificar home → navegar
+#
+# Uso:
+#   auto run login.auto
+#   auto-android run login.auto
+
+# 1. Lanzar la app
+launch dev.autopilot.test.Explorea
+waitFor "Explorea" 10
+screenshot /tmp/01-auth.png
+```
+
+**Linea por linea:**
+- `launch` arranca la app por su bundle/package ID.
+- `waitFor "Explorea" 10` espera hasta 10 segundos a que aparezca un elemento con texto "Explorea". Si la app tarda en arrancar (cold start), el timeout lo absorbe.
+- `screenshot` captura evidencia del estado actual.
+
+```bash
+# 2. Autenticacion con PIN
+tap "Desbloquear con codigo"
+waitFor "Ingresa tu codigo" 5
+tap "1"
+tap "2"
+tap "3"
+tap "4"
+screenshot /tmp/02-code-entered.png
+```
+
+**Linea por linea:**
+- `tap "Desbloquear con codigo"` busca un elemento con ese texto y hace tap. Las comillas son necesarias porque hay espacios.
+- Los `tap "1"`, `tap "2"`, etc. tocan los botones del teclado numerico. Cada uno es un tap independiente.
+- No hay `waitFor` entre los taps del PIN porque los botones ya estan en pantalla. El `waitFor` inicial garantizo que la UI cargo.
+
+```bash
+# 3. Verificar home y navegar
+waitFor "Inicio" 5
+screenshot /tmp/03-home.png
+
+tap "Aventura"
+screenshot /tmp/04-filtered.png
+
+swipe up
+screenshot /tmp/05-scrolled.png
+```
+
+**Linea por linea:**
+- `waitFor "Inicio" 5` verifica que la autenticacion fue exitosa — esperamos la pantalla principal.
+- `tap "Aventura"` filtra contenido por categoria.
+- `swipe up` hace scroll hacia arriba (el gesto va hacia arriba, el contenido se mueve hacia abajo).
+
+---
+
+## Errores comunes y como resolverlos
+
+### "No elements found matching 'X'"
+
+**Causa:** El texto que buscas no coincide exactamente con el que tiene el elemento en el arbol AX.
+
+**Solucion:** Usa `auto tree -s "X"` para ver que elementos existen. A veces el label es diferente del texto visible (e.g., un boton muestra "Sign In" pero su `accessibilityIdentifier` es "signInButton").
+
+```bash
+# Depurar
+auto tree -s "Sign"
+# Ver todo el arbol
+auto tree
+```
+
+### "Timeout: 'X' not found after 10s"
+
+**Causa:** El elemento no aparecio dentro del timeout de `waitFor`.
+
+**Posibles razones:**
+1. La app no termino de cargar (aumenta el timeout)
+2. El texto cambio entre versiones de la app
+3. La pantalla esperada nunca aparecio (error en la logica del flujo)
+
+**Solucion:** Agrega un `screenshot` justo antes del `waitFor` para ver en que estado esta la UI:
+
+```bash
+screenshot /tmp/debug-before-wait.png
+waitFor "Welcome" 15
+```
+
+### "FAIL at line N: ..."
+
+**Causa:** Un comando fallo durante la ejecucion del script. El runner imprime el numero de linea y el error, luego sale con `exit(1)`.
+
+**Solucion:** El numero de linea apunta a la linea del archivo `.auto` (incluyendo comentarios y lineas vacias). Abre el archivo y ve que comando esta en esa linea.
+
+### La app se queda en un estado inesperado
+
+**Solucion:** Agrega `terminate` + `launch` al inicio del script para garantizar estado limpio:
+
+```bash
+terminate com.example.app
+wait 1
+launch com.example.app
+waitFor "Login" 10
+```
+
+### Tap no hace nada (no falla, pero no pasa nada)
+
+**Causa posible en iOS:** Algunos elementos de SwiftUI (especialmente botones en NavigationBar) no se exponen correctamente via macOS Accessibility. `tree` puede mostrar `AXChildren=[0]` para el NavigationBar.
+
+**Solucion:** Usa `auto inspect "NavigationBar"` para debug profundo. Si el elemento realmente no esta expuesto, usa `tapAt <x> <y>` como workaround con coordenadas absolutas.
+
+### El script funciona en iOS pero no en Android (o viceversa)
+
+**Causa:** Estas usando un comando que solo existe en una plataforma (`camera`, `inject`, `build`, `index`, `inspect` son solo iOS).
+
+**Solucion:** Mantiene los comandos cross-platform: `tap`, `waitFor`, `screenshot`, `swipe`, `launch`, `terminate`, `biometric`, `wait`, `type`, `exists`.
+
+---
+
+## Referencia rapida del formato
+
+```
+# Comentario
+comando                          # Sin argumentos
+comando argumento                # Un argumento
+comando "argumento con espacios" # Quoting con comillas dobles
+comando 'otro argumento'         # Quoting con comillas simples
+comando a,b,c                    # Multi-tap (especifico de tap)
+```
+
+El parser (`ScriptParser.swift`) es deliberadamente minimalista: ~50 lineas de codigo. No hay variables, no hay condicionales, no hay macros. Si el formato se siente limitante, es intencional — la complejidad pertenece al codigo Swift, no al script.
+
+---
+
+**Ver tambien:**
+- [Apendice A — Referencia de Comandos](comandos.md) para la lista completa de comandos disponibles
+- [Capitulo 2 — Arquitectura](../02-arquitectura.md) para entender como funciona `DeviceBridge`
+- [Capitulo 9 — El agente Android](../09-el-agente-android.md) para las diferencias de ejecucion entre plataformas


### PR DESCRIPTION
## Summary
- **Apendice A** (`docs/libro/apendices/comandos.md`): referencia completa de los ~30 comandos del CLI, agrupados por categoria (conexion, arbol/busqueda, interaccion, app, dispositivo, media, biometria, camera, build, config, script). Cada comando tiene sintaxis, plataforma (iOS/Android/ambas), descripcion y ejemplo.
- **Apendice B** (`docs/libro/apendices/scripts.md`): tutorial del formato `.auto` — sintaxis basica, quoting, ejecucion cross-platform, 5 patrones/buenas practicas, ejemplo completo de login paso a paso, y seccion de errores comunes con soluciones.
- **SKILL.md** actualizado: estructura del libro ahora refleja capitulos 8-10, incluye `scripts.md` en apendices, y tiene nota de mantenimiento para cuando se agregan comandos nuevos.
- **libro/README.md** actualizado: indice incluye capitulo 10 (placeholder paridad Android) y apendice de scripts.

## Test plan
- [ ] Verificar que los links internos entre apendices funcionan
- [ ] Verificar que todos los comandos de `CommandDispatcher.swift`, `CLI/main.swift` y `CLIAndroid/main.swift` estan documentados en `comandos.md`
- [ ] Leer `scripts.md` y verificar que los ejemplos coinciden con scripts reales en `scripts/examples/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)