### PR TITLE
fix: agregar inspect al autocomplete + index cross-platform

### DIFF
--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -24,7 +24,8 @@ const AUTO_COMMANDS = [
   { label: "exists", detail: "Verificar existencia", insertText: 'exists "${1:element}"' },
   { label: "waitFor", detail: "Esperar elemento", insertText: 'waitFor "${1:element}" ${2:10}' },
   { label: "elementAt", detail: "Elemento en coordenada", insertText: "elementAt ${1:x} ${2:y}" },
-  { label: "index", detail: "Listar elementos con $N (iOS)", platform: "ios" as const },
+  { label: "index", detail: "Listar elementos con $N" },
+  { label: "inspect", detail: "Inspeccionar elemento", insertText: 'inspect "${1:query}"' },
 
   // Interacción
   { label: "tap", detail: "Tap en elemento", insertText: 'tap "${1:element}"' },
@@ -173,7 +174,7 @@ function App() {
           [/#.*$/, "comment"],
           [/"[^"]*"/, "string"],
           [/'[^']*'/, "string"],
-          [/\b(ping|tree|tap|doubleTap|longPress|type|clear|swipe|scroll|tapAt|elementAt|exists|waitFor|wait|sleep|screenshot|launch|terminate|install|biometric|faceid|paste|openurl|media|build|camera|inject|index|config|run|boot|shutdown|list)\b/, "keyword"],
+          [/\b(ping|tree|tap|doubleTap|longPress|type|clear|swipe|scroll|tapAt|elementAt|exists|waitFor|wait|sleep|screenshot|launch|terminate|install|biometric|faceid|paste|openurl|media|build|camera|inject|index|inspect|config|run|boot|shutdown|list)\b/, "keyword"],
           [/\b(enroll|match|fail|status|start|feed|stop|up|down|left|right)\b/, "type"],
           [/--env\b/, "annotation"],
           [/\b\d+\b/, "number"],


### PR DESCRIPTION
## Summary
- Agrega comando `inspect` al autocomplete del editor (faltaba tras PR #27)
- `index` ya no tiene restricción "(iOS)" — Android lo soporta desde PR #27
- `inspect` agregado al syntax highlighting de Monaco

Resuelve el comentario de revisión en PR #27.

## Test plan
- [ ] Abrir editor, escribir `insp` → aparece `inspect` como sugerencia
- [ ] Escribir `index` → aparece sin "(iOS)" en el detail
- [ ] Escribir `inspect "Login"` → se resalta como keyword

🤖 Generated with [Claude Code](https://claude.com/claude-code)