### PR TITLE
fix: Inspector comillas + thread cleanup en timeout

### DIFF
--- a/editor/src-tauri/src/lib.rs
+++ b/editor/src-tauri/src/lib.rs
@@ -304,29 +304,38 @@ fn inspect(platform: Option<String>) -> Result<Value, String> {
     let (screenshot_tx, screenshot_rx) = mpsc::channel::<String>();
     let (tree_tx, tree_rx) = mpsc::channel::<Result<(Vec<Value>, Vec<String>), String>>();
 
-    // Run screenshot and tree in parallel
+    // Run screenshot and tree in parallel (keep handles for cleanup)
     let bin_screenshot = bin.clone();
-    std::thread::spawn(move || {
+    let screenshot_handle = std::thread::spawn(move || {
         let result = take_screenshot(&bin_screenshot);
         let _ = screenshot_tx.send(result);
     });
 
     let bin_tree = bin.clone();
-    std::thread::spawn(move || {
+    let tree_handle = std::thread::spawn(move || {
         let result = run_cli(&bin_tree, &["tree"])
             .map(|stdout| parse_tree_output(&stdout));
         let _ = tree_tx.send(result);
     });
 
     // Collect results with timeout
-    let image_b64 = screenshot_rx.recv_timeout(timeout)
-        .unwrap_or_else(|_| {
+    let image_b64 = match screenshot_rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(_) => {
             eprintln!("inspect: screenshot timed out after 10s");
+            let _ = screenshot_handle.join();
             String::new()
-        });
+        }
+    };
 
-    let (elements, labels) = tree_rx.recv_timeout(timeout)
-        .map_err(|_| "Inspect timeout: tree took longer than 10 seconds. Is the device connected?".to_string())?
+    let tree_result = match tree_rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(_) => {
+            let _ = tree_handle.join();
+            return Err("Inspect timeout: tree took longer than 10 seconds. Is the device connected?".to_string());
+        }
+    };
+    let (elements, labels) = tree_result
         .map_err(|e| format!("Tree failed: {}", e))?;
 
     // Index: for Android, generate from tree; for iOS, call `auto index`

--- a/editor/src/Inspector.tsx
+++ b/editor/src/Inspector.tsx
@@ -21,14 +21,14 @@ interface ParsedElement extends AXElement {
 function makeActions(label: string, suffix: string) {
   const ref = suffix ? `${label}${suffix}` : label;
   return [
-    { label: "tap", icon: "👆", cmd: `tap ${ref}` },
-    { label: "doubleTap", icon: "👆👆", cmd: `doubleTap ${ref}` },
-    { label: "longPress", icon: "✊", cmd: `longPress ${ref} 1` },
-    { label: "type", icon: "⌨️", cmd: `type ${ref} "text"` },
-    { label: "clear", icon: "🗑", cmd: `clear ${ref}` },
-    { label: "scroll", icon: "📜", cmd: `scroll ${ref} down` },
-    { label: "waitFor", icon: "⏳", cmd: `waitFor ${ref} 10` },
-    { label: "exists", icon: "❓", cmd: `exists ${ref}` },
+    { label: "tap", icon: "👆", cmd: `tap "${ref}"` },
+    { label: "doubleTap", icon: "👆👆", cmd: `doubleTap "${ref}"` },
+    { label: "longPress", icon: "✊", cmd: `longPress "${ref}" 1` },
+    { label: "type", icon: "⌨️", cmd: `type "${ref}" "text"` },
+    { label: "clear", icon: "🗑", cmd: `clear "${ref}"` },
+    { label: "scroll", icon: "📜", cmd: `scroll "${ref}" down` },
+    { label: "waitFor", icon: "⏳", cmd: `waitFor "${ref}" 10` },
+    { label: "exists", icon: "❓", cmd: `exists "${ref}"` },
   ];
 }
 


### PR DESCRIPTION
## Summary
- Inspector genera comandos con comillas: `tap "Login Button"` en vez de `tap Login Button`
- Threads de screenshot/tree se joinean en timeout para evitar procesos huérfanos

Estos fixes se aplicaron en PR #26 pero se pushearon después del merge, así que nunca llegaron a main.

## Test plan
- [ ] Click elemento en Inspector → comando generado tiene comillas
- [ ] Desconectar device → inspect no deja threads colgados (timeout 10s)
- [ ] `npx tsc --noEmit` pasa
- [ ] `cargo check` pasa

🤖 Generated with [Claude Code](https://claude.com/claude-code)