### PR TITLE
feat: benchmark suite — AutoPilot vs Maestro vs WDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ local.properties
 
 # Compiled dylibs
 *.dylib
+
+# Benchmark suite (runtime artifacts)
+scripts/benchmark-suite/tools/
+!scripts/benchmark-suite/tools/.gitkeep
+scripts/benchmark-suite/evidence/
+scripts/benchmark-suite/benchmark-results/

--- a/scripts/benchmark-suite/lib/screenshots.sh
+++ b/scripts/benchmark-suite/lib/screenshots.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Screenshot capture helpers
+
+EVIDENCE_DIR="${EVIDENCE_DIR:-evidence}"
+
+# capture_screenshot tool test step
+capture_screenshot() {
+  local tool="$1" test_name="$2" step="$3"
+  local path="$EVIDENCE_DIR/${tool}-${test_name}-step${step}.png"
+  xcrun simctl io booted screenshot "$path" 2>/dev/null || true
+}

--- a/scripts/benchmark-suite/lib/simulator.sh
+++ b/scripts/benchmark-suite/lib/simulator.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Simulator management
+
+BUNDLE_ID="dev.autopilot.test.Explorea"
+
+ensure_simulator_booted() {
+  local booted
+  booted=$(xcrun simctl list devices booted -j | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for runtime, devices in data.get('devices', {}).items():
+    for d in devices:
+        if d.get('state') == 'Booted':
+            print(d['udid'])
+            sys.exit(0)
+" 2>/dev/null || true)
+
+  if [ -n "$booted" ]; then
+    echo "Simulator already booted: $booted"
+    return
+  fi
+
+  echo "Booting simulator..."
+  local udid
+  udid=$(xcrun simctl list devices available -j | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for runtime, devices in data.get('devices', {}).items():
+    if 'iOS' not in runtime:
+        continue
+    for d in devices:
+        if d.get('isAvailable') and 'iPhone' in d.get('name', ''):
+            print(d['udid'])
+            sys.exit(0)
+")
+  xcrun simctl boot "$udid"
+  open -a Simulator
+  sleep 5
+  echo "Booted: $udid"
+}
+
+ensure_app_installed() {
+  local project_root="$1"
+  if xcrun simctl get_app_container booted "$BUNDLE_ID" > /dev/null 2>&1; then
+    echo "App already installed: $BUNDLE_ID"
+    return
+  fi
+  echo "App not installed. Please install $BUNDLE_ID first."
+  exit 1
+}
+
+reset_app() {
+  xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+}

--- a/scripts/benchmark-suite/lib/timing.sh
+++ b/scripts/benchmark-suite/lib/timing.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Shared timing functions for benchmark suite
+
+RESULTS_DIR="${RESULTS_DIR:-benchmark-results}"
+TOTAL_RUNS="${TOTAL_RUNS:-11}"
+WARMUP_RUNS=1
+MEASURED_RUNS=$((TOTAL_RUNS - WARMUP_RUNS))
+BUNDLE_ID="dev.autopilot.test.Explorea"
+
+now_ms() {
+  python3 -c "import time; print(int(time.time()*1000))"
+}
+
+# run_single tool test run_number command...
+run_single() {
+  local tool="$1" test_name="$2" run_number="$3"
+  shift 3
+
+  local start_ms end_ms total_ms exit_code
+  start_ms=$(now_ms)
+
+  set +e
+  "$@" > /dev/null 2>&1
+  exit_code=$?
+  set -e
+
+  end_ms=$(now_ms)
+  total_ms=$((end_ms - start_ms))
+
+  echo "{\"tool\":\"$tool\",\"test\":\"$test_name\",\"run\":$run_number,\"total_ms\":$total_ms,\"exit_code\":$exit_code}"
+}
+
+# run_benchmark tool test command...
+run_benchmark() {
+  local tool="$1" test_name="$2"
+  shift 2
+  local cmd=("$@")
+  local outfile="$RESULTS_DIR/${tool}-${test_name}.jsonl"
+
+  echo ">>> [$tool] $test_name: warm-up..."
+  run_single "$tool" "$test_name" 0 "${cmd[@]}" > /dev/null || true
+
+  xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+  sleep 1
+
+  echo ">>> [$tool] $test_name: $MEASURED_RUNS runs..."
+  for i in $(seq 1 "$MEASURED_RUNS"); do
+    local result
+    result=$(run_single "$tool" "$test_name" "$i" "${cmd[@]}")
+    echo "$result" >> "$outfile"
+
+    local ms
+    ms=$(echo "$result" | python3 -c "import sys,json; print(json.load(sys.stdin)['total_ms'])")
+    echo "    run $i: ${ms}ms"
+
+    xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+    sleep 1
+  done
+}

--- a/scripts/benchmark-suite/lib/tools-setup.sh
+++ b/scripts/benchmark-suite/lib/tools-setup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Download/copy tools into local sandbox
+
+setup_tools() {
+  local tools_dir="$1"
+  local project_root="$2"
+
+  echo "=== Setting up tools ==="
+
+  # AutoPilot
+  if [ -x "$tools_dir/auto" ]; then
+    echo "[autopilot] Already exists"
+  elif [ -x "$project_root/cli/.build/debug/auto" ]; then
+    cp "$project_root/cli/.build/debug/auto" "$tools_dir/auto"
+    echo "[autopilot] Copied from build"
+  else
+    echo "[autopilot] Building..."
+    (cd "$project_root/cli" && swift build) > /dev/null 2>&1
+    cp "$project_root/cli/.build/debug/auto" "$tools_dir/auto"
+    echo "[autopilot] Built and copied"
+  fi
+
+  # Maestro
+  if [ -x "$tools_dir/maestro" ]; then
+    echo "[maestro] Already exists"
+  elif [ -x "$HOME/.maestro/bin/maestro" ]; then
+    ln -sf "$HOME/.maestro/bin/maestro" "$tools_dir/maestro"
+    echo "[maestro] Linked from ~/.maestro/"
+  else
+    echo "[maestro] Downloading..."
+    curl -Ls "https://get.maestro.mobile.dev" | bash > /dev/null 2>&1
+    ln -sf "$HOME/.maestro/bin/maestro" "$tools_dir/maestro"
+    echo "[maestro] Installed and linked"
+  fi
+
+  # WDA (WebDriverAgent) — must be running externally on port 8100
+  local wda_port="${WDA_PORT:-8100}"
+  if curl -s "http://127.0.0.1:$wda_port/status" | grep -q '"ready"' 2>/dev/null; then
+    echo "[wda] Running on port $wda_port"
+  else
+    echo "[wda] ERROR: WebDriverAgent not running on port $wda_port"
+    echo "      Start it with: xcodebuild test -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'platform=iOS Simulator,name=iPhone 16 Pro'"
+    exit 1
+  fi
+
+  echo ""
+}

--- a/scripts/benchmark-suite/report/comparison-dashboard.html
+++ b/scripts/benchmark-suite/report/comparison-dashboard.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AutoPilot Lab — Benchmark</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+<script src="https://unpkg.com/htm@3/dist/htm.js" crossorigin></script>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;500;600;700;800;900&display=swap');
+  html{font-size:clamp(10px,0.85vw,16px)}
+  body{font-family:'Inter',-apple-system,system-ui,sans-serif;margin:0}
+  .mono{font-family:'JetBrains Mono',monospace}
+  .scr{overflow-y:auto;scrollbar-width:thin;scrollbar-color:#334155 transparent}
+  .scr::-webkit-scrollbar{width:5px}.scr::-webkit-scrollbar-thumb{background:#334155;border-radius:4px}
+  @keyframes fadeIn{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}
+  .fi{animation:fadeIn .4s ease-out}
+</style>
+</head>
+<body class="bg-slate-950 text-slate-200 h-screen flex flex-col overflow-hidden">
+<div id="root" class="h-full flex flex-col"></div>
+
+<script>
+const h = htm.bind(React.createElement);
+const {useState,useEffect,useRef} = React;
+
+/* ═══════════ DATA ═══════════ */
+
+const S = {
+  ap:{name:"AutoPilot",color:"#10b981",status:"IN DEV",login:10184,bio:7610,size:"~1 MB",deps:"0",loc:"32",protocol:"IPC Directa",runtime:"Swift Nativo",apiCount:22,
+    layers:["Capa CLI (Swift Nativo)","AXUIElement API (IPC)","CGEvent (Sintético)","Simulator Process"],
+    archDesc:"Comunicación directa con el proceso del Simulator via macOS Accessibility APIs. Sin servidor HTTP, sin serialización JSON.",
+    postTap:"Ninguna",search:"AX query (~60ms)",retry:"Solo waitFor",
+    why:"AXUIElement + CGEvent = IPC del sistema operativo. Sin HTTP, sin JSON, sin intermediarios."},
+  ma:{name:"Maestro",color:"#f59e0b",status:"STABLE",login:26067,bio:null,size:"398 MB",deps:"193 JARs",loc:"26",protocol:"gRPC",runtime:"JVM Embebido",apiCount:23,
+    layers:["Capa CLI (Java/JVM)","gRPC Handler","XCTest Driver (Sideloaded)","Apple Accessibility"],
+    archDesc:"Proceso Java se comunica via gRPC con un driver XCTest sideloaded. Cada comando viaja 4 capas.",
+    postTap:"Wait-idle 1-2s",search:"Retry loop 5s",retry:"Todos los cmds",
+    why:"Cada tapOn = retry loop + wait-for-idle + tap + wait. ~2s extra por interacción."},
+  wda:{name:"WDA",color:"#8b5cf6",status:"STABLE",login:11680,bio:10650,size:"48 MB",deps:"0",loc:"234",protocol:"HTTP/JSON",runtime:"XCUITest",apiCount:29,
+    layers:["Capa CLI (Node.js HTTP)","JSON / HTTP :8100","WDA Server (XCTest Runner)","XCUITest APIs"],
+    archDesc:"WDA corre como XCTest runner con HTTP server en :8100. Cada acción = request JSON.",
+    postTap:"Ninguna",search:"Predicate HTTP (~300ms)",retry:"Ninguno (manual)",
+    why:"2 HTTP round-trips por interacción (find + click). Sin retry pero con latencia HTTP."},
+};
+const TK=["ap","ma","wda"];
+const fm=ms=>!ms?"N/A":ms>=1000?(ms/1000).toFixed(1)+"s":ms+"ms";
+
+const CAPS = [
+  {n:"Tap por label/id",     c:"CONTROL",  ap:1,ma:1,wda:1},
+  {n:"Tap coordenadas (x,y)",c:"CONTROL",  ap:1,ma:1,wda:1},
+  {n:"Long press",           c:"CONTROL",  ap:1,ma:1,wda:1},
+  {n:"Double tap",           c:"CONTROL",  ap:1,ma:1,wda:1},
+  {n:"Swipe / Scroll",       c:"CONTROL",  ap:1,ma:1,wda:1},
+  {n:"Pinch / Rotate",       c:"CONTROL",  ap:0,ma:0,wda:1},
+  {n:"Force touch",          c:"CONTROL",  ap:0,ma:0,wda:1},
+  {n:"Drag & drop",          c:"CONTROL",  ap:0,ma:0,wda:1},
+  {n:"Type texto",           c:"INPUT",    ap:1,ma:1,wda:1},
+  {n:"Clear campo",          c:"INPUT",    ap:1,ma:1,wda:1},
+  {n:"Dismiss keyboard",     c:"INPUT",    ap:0,ma:1,wda:1},
+  {n:"Biometric enroll",     c:"SENSORS",  ap:1,ma:0,wda:0},
+  {n:"Biometric match/fail", c:"SENSORS",  ap:1,ma:0,wda:2},
+  {n:"Camera mock",          c:"SENSORS",  ap:1,ma:0,wda:0},
+  {n:"Location sim",         c:"SENSORS",  ap:0,ma:1,wda:1},
+  {n:"Screenshot",           c:"MEDIA",    ap:1,ma:1,wda:1},
+  {n:"Video recording",      c:"MEDIA",    ap:0,ma:1,wda:1},
+  {n:"Clipboard write",      c:"MEDIA",    ap:1,ma:1,wda:1},
+  {n:"Clipboard read",       c:"MEDIA",    ap:1,ma:2,wda:1},
+  {n:"Add media to library", c:"MEDIA",    ap:1,ma:0,wda:0},
+  {n:"Launch app",           c:"APP",      ap:1,ma:1,wda:1},
+  {n:"Terminate app",        c:"APP",      ap:1,ma:1,wda:1},
+  {n:"Install app",          c:"APP",      ap:1,ma:1,wda:0},
+  {n:"Open deep link / URL", c:"APP",      ap:1,ma:1,wda:1},
+  {n:"Accessibility tree",   c:"QUERIES",  ap:1,ma:0,wda:1},
+  {n:"Element search",       c:"QUERIES",  ap:1,ma:1,wda:1},
+  {n:"Predicate / XPath",    c:"QUERIES",  ap:0,ma:0,wda:1},
+  {n:"Wait for element",     c:"QUERIES",  ap:1,ma:1,wda:0},
+  {n:"Lock / Unlock",        c:"DEVICE",   ap:0,ma:0,wda:1},
+  {n:"Home button",          c:"DEVICE",   ap:0,ma:0,wda:1},
+  {n:"Alert handling",       c:"DEVICE",   ap:0,ma:2,wda:1},
+  {n:"Dark/Light mode",      c:"DEVICE",   ap:0,ma:0,wda:1},
+  {n:"DSL nativo (.auto)",   c:"SCRIPT",   ap:1,ma:0,wda:0},
+  {n:"YAML flows",           c:"SCRIPT",   ap:0,ma:1,wda:0},
+  {n:"JavaScript",           c:"SCRIPT",   ap:0,ma:1,wda:1},
+  {n:"Sub-flows",            c:"SCRIPT",   ap:0,ma:1,wda:0},
+  {n:"Variables / ENV",      c:"SCRIPT",   ap:0,ma:1,wda:1},
+];
+
+const TL_LOGIN = {
+  ap:[
+    {label:"Auth Screen",     time:"0.3s", img:"../evidence/autopilot-login-step1.png", detail:"Spawn directo via simctl"},
+    {label:"PIN Screen",      time:"0.9s", img:"../evidence/autopilot-login-step2.png", detail:"CGEvent tap 'Usar código'"},
+    {label:"Home (logged in)",time:"1.7s", img:"../evidence/autopilot-login-step3.png", detail:"PIN 1234 + Confirmar"},
+    {label:"Aventura",        time:"10.2s",img:"../evidence/autopilot-login-step4.png", detail:"Tap categoría + swipe up"},
+  ],
+  ma:[
+    {label:"Auth Screen",     time:"1.2s",  img:"../evidence/maestro-login-step1.png", detail:"gRPC → XCTest init"},
+    {label:"PIN Screen",      time:"6.0s",  img:"../evidence/maestro-login-step2.png", detail:"tapOn + wait-idle ~2s"},
+    {label:"Home (logged in)",time:"16s",   img:"../evidence/maestro-login-step3.png", detail:"5× retry+idle (~2s c/u)"},
+    {label:"Aventura",        time:"26.1s", img:"../evidence/maestro-login-step4.png", detail:"tapOn + scroll"},
+  ],
+  wda:[
+    {label:"Auth Screen",     time:"0.2s",  img:"../evidence/wda-login-step1.png", detail:"HTTP POST /session + launch"},
+    {label:"PIN Screen",      time:"2.9s",  img:"../evidence/wda-login-step2.png", detail:"findAndTap (2 HTTP)"},
+    {label:"Home (logged in)",time:"5.3s",  img:"../evidence/wda-login-step3.png", detail:"5× find+click (10 HTTP)"},
+    {label:"Aventura",        time:"11.7s", img:"../evidence/wda-login-step4.png", detail:"findAndTap + screenshot"},
+  ],
+};
+const TL_BIO = {
+  ap:[
+    {label:"Enroll Face ID",  time:"2.7s", img:"../evidence/autopilot-biometric-step1.png", detail:"AppleScript menu Enrolled"},
+    {label:"Home (bio match)",time:"7.6s", img:"../evidence/autopilot-biometric-step2.png", detail:"Tap + biometric match"},
+  ],
+  ma:[
+    {label:"No soportado",    time:"—",    img:null, detail:"Sandbox JS sin acceso a simctl"},
+  ],
+  wda:[
+    {label:"App lanzada",     time:"0.3s", img:"../evidence/wda-biometric-step1.png", detail:"HTTP POST /session + launch"},
+    {label:"Auth + Face ID",  time:"3.0s", img:"../evidence/wda-biometric-step2.png", detail:"AppleScript enroll + tap"},
+    {label:"Home (bio match)",time:"10.7s",img:"../evidence/wda-biometric-step3.png", detail:"simctl match + success"},
+  ],
+};
+
+const SCRIPTS = {
+  ap:{lang:"auto",code:"# Benchmark: Login + navegacion\n# Con screenshots como evidencia\n\nlaunch dev.autopilot.test.Explorea\nwaitFor \"Explorea\" 10\nscreenshot evidence/autopilot-login-step1.png\ntap \"Usar c\u00f3digo\"\nwaitFor \"Ingresa tu c\u00f3digo\" 5\nscreenshot evidence/autopilot-login-step2.png\ntap \"1\"\ntap \"2\"\ntap \"3\"\ntap \"4\"\ntap \"Confirmar\"\nwaitFor \"Inicio\" 5\nscreenshot evidence/autopilot-login-step3.png\ntap \"Aventura\"\nswipe up\nscreenshot evidence/autopilot-login-step4.png"},
+  ma:{lang:"yaml",code:"appId: dev.autopilot.test.Explorea\n---\n# Benchmark: Login + navegacion\n\n- launchApp\n\n- assertVisible: \"Explorea\"\n- takeScreenshot: evidence/maestro-login-step1\n\n- tapOn: \"Usar c\u00f3digo\"\n\n- assertVisible: \"Ingresa tu c\u00f3digo\"\n- takeScreenshot: evidence/maestro-login-step2\n\n- tapOn: \"1\"\n- tapOn: \"2\"\n- tapOn: \"3\"\n- tapOn: \"4\"\n- tapOn: \"Confirmar\"\n\n- assertVisible: \"Inicio\"\n- takeScreenshot: evidence/maestro-login-step3\n\n- tapOn: \"Aventura\"\n- scroll\n- takeScreenshot: evidence/maestro-login-step4"},
+  wda:{lang:"js",code:"const { createSession, deleteSession,\n  findAndTap, waitForElement,\n  saveScreenshot, terminateApp,\n  activateApp, sleep, EVIDENCE_DIR,\n} = require('./appium-helpers');\n\nasync function main() {\n  const sid = await createSession();\n  try {\n    await terminateApp(sid);\n    await sleep(500);\n    await activateApp(sid);\n    await waitForElement(sid, 'Explorea', 10000);\n    await saveScreenshot(sid, EVIDENCE_DIR+'/wda-login-step1.png');\n    await findAndTap(sid, 'Usar c\u00f3digo');\n    await waitForElement(sid, 'Ingresa tu c\u00f3digo', 5000);\n    await saveScreenshot(sid, EVIDENCE_DIR+'/wda-login-step2.png');\n    await findAndTap(sid, '1');\n    await findAndTap(sid, '2');\n    await findAndTap(sid, '3');\n    await findAndTap(sid, '4');\n    await findAndTap(sid, 'Confirmar');\n    await waitForElement(sid, 'Inicio', 5000);\n    await saveScreenshot(sid, EVIDENCE_DIR+'/wda-login-step3.png');\n    await findAndTap(sid, 'Aventura');\n    await sleep(500);\n    await saveScreenshot(sid, EVIDENCE_DIR+'/wda-login-step4.png');\n  } finally {\n    await deleteSession(sid);\n  }\n}\nmain().catch(err => {\n  console.error(err.message);\n  process.exit(1);\n});\n// + 150 LOC helper library (appium-helpers.js)"},
+};
+
+const ROAD = [
+  {title:"Video Recording",desc:"Captura de buffers de video sin pérdida de frames.",priority:"ALTA",difficulty:"MEDIA",status:"TODO"},
+  {title:"Location Simulation",desc:"Inyección de rutas GPS via CoreLocation.",priority:"MEDIA",difficulty:"BAJA",status:"TODO"},
+  {title:"Alert Handling",desc:"Manejo automático de system alerts y permisos.",priority:"ALTA",difficulty:"MEDIA",status:"TODO"},
+  {title:"Sub-flows",desc:"Composición de scripts .auto reutilizables.",priority:"ALTA",difficulty:"MEDIA",status:"TODO"},
+  {title:"Variables / ENV",desc:"Scripts parametrizados con variables de entorno.",priority:"MEDIA",difficulty:"BAJA",status:"TODO"},
+  {title:"Network Intercept",desc:"Mock de respuestas API directamente en el simulador.",priority:"CRÍTICA",difficulty:"ALTA",status:"IN PROGRESS"},
+  {title:"Pinch / Rotate",desc:"Gestos multi-touch para mapas y fotos.",priority:"BAJA",difficulty:"ALTA",status:"ARCHIVED"},
+  {title:"Siri Commands",desc:"Automatización de intenciones de voz.",priority:"BAJA",difficulty:"ALTA",status:"ARCHIVED"},
+];
+
+/* ═══════════ HELPERS ═══════════ */
+
+function Chk({v,c}){
+  if(v===1) return h`<div class="w-6 h-6 rounded-md flex items-center justify-center" style=${{background:c+'25'}}><span style=${{color:c}} class="font-black text-xs">✓</span></div>`;
+  if(v===2) return h`<div class="w-6 h-6 rounded-md bg-amber-500/15 flex items-center justify-center"><span class="text-amber-400 font-black text-[0.82rem]">~</span></div>`;
+  return h`<div class="w-6 h-6 rounded-md bg-slate-800/50 flex items-center justify-center"><span class="text-slate-700 text-xs">✗</span></div>`;
+}
+
+function Phone({img}){
+  if(!img) return h`<div class="w-full aspect-[9/19] bg-red-950 rounded-[2rem] border-[5px] border-slate-900 relative overflow-hidden shadow-2xl flex items-center justify-center">
+    <div class="absolute top-0 left-1/2 -translate-x-1/2 w-1/3 h-5 bg-black rounded-b-2xl z-20"/>
+    <div class="flex flex-col items-center gap-3"><div class="text-red-500 text-4xl">✗</div><p class="text-[0.82rem] text-red-400 font-black uppercase">No soportado</p></div>
+    <div class="absolute bottom-3 left-1/2 -translate-x-1/2 w-1/3 h-1 bg-white/10 rounded-full"/>
+  </div>`;
+  return h`<div class="w-full aspect-[9/19] bg-slate-900 rounded-[2rem] border-[5px] border-slate-900 relative overflow-hidden shadow-2xl transition-all duration-500">
+    <div class="absolute top-0 left-1/2 -translate-x-1/2 w-1/3 h-5 bg-black rounded-b-2xl z-20 flex items-center justify-center"><div class="w-8 h-1 bg-slate-800 rounded-full"/></div>
+    <img src=${img} class="w-full h-full object-cover" alt="screenshot" onerror="this.style.display='none'"/>
+    <div class="absolute bottom-3 left-1/2 -translate-x-1/2 w-1/3 h-1 bg-white/10 rounded-full"/>
+  </div>`;
+}
+
+function Syntax({code,lang}){
+  const esc = s => s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  // placeholder trick: mark strings before inserting any HTML tags, to avoid
+  // the string-regex matching inside already-inserted style="color:..." attributes
+  const markStrs = s => s.replace(/"([^"]+)"/g, (_,v)=>`\x01${v}\x01`);
+  const restStrs = s => s.replace(/\x01([^\x01]*)\x01/g, (_,v)=>`<span style='color:#38bdf8'>"${v}"</span>`);
+  const hl = line => {
+    const e = esc(line);
+    if(lang==='auto'){
+      if(e.startsWith('#')) return `<span style='color:#475569;font-style:italic'>${e}</span>`;
+      if(!e.trim()) return e;
+      let r = markStrs(e);
+      r = r.replace(/^(launch|waitFor|tap|swipe|screenshot|terminate|biometric|type|config|ping)/,
+          (_,c) => `<b style='color:#10b981'>${c}</b>`);
+      r = r.replace(/\b(up|down|left|right)\b/g, (_,k) => `<span style='color:#f59e0b'>${k}</span>`);
+      r = r.replace(/(\s)(\d+)(\s|$)/g, (_,a,n,b) => `${a}<span style='color:#f59e0b'>${n}</span>${b}`);
+      return restStrs(r);
+    }
+    if(lang==='yaml'){
+      if(e==='---') return `<span style='color:#475569'>---</span>`;
+      if(e.startsWith('#')) return `<span style='color:#475569;font-style:italic'>${e}</span>`;
+      if(!e.trim()) return e;
+      let r = markStrs(e);
+      r = r.replace(/^(- ?)(launchApp|assertVisible|tapOn|takeScreenshot|scroll)/,
+          (_,d,cmd) => `${d}<b style='color:#f59e0b'>${cmd}</b>`);
+      r = r.replace(/^(\w+)(:\s)/,
+          (_,k,c) => `<b style='color:#f59e0b'>${k}</b><span style='color:#64748b'>${c}</span>`);
+      r = r.replace(/: /g, `<span style='color:#64748b'>: </span>`);
+      return restStrs(r);
+    }
+    // JS: mark single-quoted strings before inserting any HTML tags (same collision-avoidance trick)
+    if(e.trim().startsWith('//')) return `<span style="color:#475569;font-style:italic">${e}</span>`;
+    let js = e.replace(/'([^']+)'/g, (_,s) => `\x01${s}\x01`);
+    js = js
+      .replace(/\b(await|const|async|try|finally|require)\b/g, (_,k) => `<b style="color:#8b5cf6">${k}</b>`)
+      .replace(/(\w+)\(/g, (_,fn) => `<span style="color:#10b981">${fn}</span>(`)
+      .replace(/\/\/ (.+)$/, (_,c) => `<span style="color:#475569;font-style:italic">// ${c}</span>`);
+    return js.replace(/\x01([^\x01]*)\x01/g, (_,s) => `<span style="color:#38bdf8">'${s}'</span>`);
+  };
+  return h`<pre class="text-[0.875rem] mono leading-relaxed">${code.split('\n').map((l,i)=>h`<div key=${i} dangerouslySetInnerHTML=${{__html:hl(l)||'&nbsp;'}}/>`)}</pre>`;
+}
+
+/* ═══════════ TABS ═══════════ */
+
+const TABS = [
+  {id:"overview",  label:"Overview",     icon:"📊"},
+  {id:"apis",      label:"APIs",         icon:"🔌"},
+  {id:"arch",      label:"Arquitectura", icon:"📦"},
+  {id:"timeline",  label:"Timeline",     icon:"⏱"},
+  {id:"scripts",   label:"Scripts",      icon:"</>"},
+  {id:"roadmap",   label:"Roadmap",      icon:"🎯"},
+];
+
+/* ── OVERVIEW ── */
+function POverview(){
+  return h`<div class="h-full flex flex-col gap-4 fi">
+    <div class="grid grid-cols-3 gap-5 shrink-0">
+      ${TK.map(k=>{const s=S[k];return h`<div key=${k} class="relative p-5 rounded-[2rem] border border-slate-800 bg-slate-900/40 hover:border-opacity-60 transition-all" style=${{borderColor:s.color+'30'}}>
+        <div class="absolute inset-0 rounded-[2rem] opacity-5" style=${{background:'linear-gradient(135deg,'+s.color+',transparent)'}}/>
+        <div class="relative">
+          <div class="flex items-center justify-between mb-4">
+            <div class="flex items-center gap-2"><div class="w-2.5 h-2.5 rounded-full" style=${{background:s.color,boxShadow:'0 0 12px '+s.color+'60'}}/><span class="text-xs font-black text-white uppercase tracking-widest italic">${s.name}</span></div>
+            <span class="text-[0.75rem] font-black px-2 py-1 rounded uppercase tracking-widest" style=${{background:s.color+'15',color:s.color,border:'1px solid '+s.color+'30'}}>${s.status}</span>
+          </div>
+          <div class="text-center mb-4"><span class="text-5xl font-black text-white tracking-tighter italic">${fm(s.login)}</span><p class="text-[0.82rem] text-slate-500 font-bold uppercase tracking-widest mt-1">Login Flow</p></div>
+          <div class="grid grid-cols-4 gap-2 pt-4 border-t border-slate-800/50">
+            ${[["Bio",fm(s.bio)],["Size",s.size],["Deps",s.deps],["LOC",s.loc]].map(([l,v])=>h`<div key=${l} class="text-center"><p class="text-[0.75rem] text-slate-500 font-bold uppercase mb-0.5">${l}</p><p class="text-[0.875rem] text-slate-300 mono font-bold">${v}</p></div>`)}
+          </div>
+        </div>
+      </div>`})}
+    </div>
+    <div class="grid grid-cols-12 gap-5 flex-1 min-h-0">
+      <div class="col-span-8 bg-slate-900/50 border border-slate-800 rounded-[2rem] overflow-hidden flex flex-col">
+        <div class="px-7 py-4 border-b border-slate-800 bg-slate-900/80 flex items-center justify-between shrink-0">
+          <h3 class="text-xs font-black text-white uppercase tracking-widest">Comparativa General</h3>
+          <div class="flex gap-2">${TK.map(k=>h`<div key=${k} class="w-2 h-2 rounded-full" style=${{background:S[k].color}}/>`)}</div>
+        </div>
+        <div class="flex-1 overflow-auto scr">
+          <table class="w-full text-[0.94rem]"><thead class="sticky top-0 bg-slate-900 z-10"><tr class="text-slate-500 border-b border-slate-800/50">
+            <th class="px-7 py-3 text-left uppercase font-black">Métrica</th>
+            ${TK.map(k=>h`<th key=${k} class="px-4 py-3 uppercase font-black italic" style=${{color:S[k].color}}>${S[k].name}</th>`)}
+          </tr></thead><tbody class="divide-y divide-slate-800/30">
+            ${[
+              ["Login Flow",fm(S.ap.login)+" ★",fm(S.ma.login),fm(S.wda.login)],
+              ["Biometría",fm(S.ap.bio)+" ★","✗ No soporta",fm(S.wda.bio)],
+              ["Runtime",S.ap.runtime,S.ma.runtime,S.wda.runtime],
+              ["Protocolo",S.ap.protocol,S.ma.protocol,S.wda.protocol],
+              ["Dependencies",S.ap.deps,S.ma.deps,S.wda.deps],
+              ["Tamaño total",S.ap.size,S.ma.size,S.wda.size],
+              ["LOC del test",S.ap.loc,S.ma.loc,S.wda.loc],
+              ["Scripting",".auto (DSL)","YAML","JavaScript"],
+              ["Post-tap",S.ap.postTap,S.ma.postTap,S.wda.postTap],
+              ["Retry",S.ap.retry,S.ma.retry,S.wda.retry],
+              ["APIs",String(S.ap.apiCount),String(S.ma.apiCount),String(S.wda.apiCount)],
+            ].map((r,i)=>h`<tr key=${i} class="hover:bg-slate-800/10 transition-colors">
+              <td class="px-7 py-2.5 font-bold text-slate-400">${r[0]}</td>
+              <td class="px-4 py-2.5 mono" style=${{color:S.ap.color}}>${r[1]}</td>
+              <td class="px-4 py-2.5 mono" style=${{color:S.ma.color}}>${r[2]}</td>
+              <td class="px-4 py-2.5 mono" style=${{color:S.wda.color}}>${r[3]}</td>
+            </tr>`)}
+          </tbody></table>
+        </div>
+      </div>
+      <div class="col-span-4 bg-slate-900/40 border border-slate-800 rounded-[2rem] p-6 flex flex-col">
+        <h3 class="text-xs font-black text-slate-400 uppercase tracking-widest mb-4 flex items-center gap-2">📈 Desempeño Visual</h3>
+        <div class="flex-1 flex flex-col justify-center space-y-6">
+          ${[{l:"Login Flow",vals:[["AP","ap",S.ap.color,S.ap.login],["WDA","wda",S.wda.color,S.wda.login],["MA","ma",S.ma.color,S.ma.login]],max:26100,err:false},
+             {l:"Biometría",vals:[["AP","ap",S.ap.color,S.ap.bio],["WDA","wda",S.wda.color,S.wda.bio],["MA","ma",S.ma.color,0]],max:12000,err:true}
+          ].map((c,ci)=>h`<div key=${ci}>
+            <p class="text-[0.82rem] text-slate-500 font-bold uppercase mb-3 tracking-widest">${c.l}</p>
+            <div class="space-y-3">
+              ${c.vals.map(([lbl,key,clr,val])=>h`<div key=${key} class="flex items-center gap-3">
+                <div class="w-8 text-[0.82rem] font-black text-slate-600 uppercase">${lbl}</div>
+                <div class="flex-1 h-1.5 bg-slate-800 rounded-full overflow-hidden relative">
+                  ${key==='ma'&&c.err
+                    ? h`<div class="absolute inset-0 bg-red-500/20 flex items-center justify-center"><span class="text-[0.94rem] text-red-500 font-black">UNSUPPORTED</span></div>`
+                    : h`<div class="h-full rounded-full transition-all duration-700" style=${{width:(val/c.max*100)+'%',background:clr,boxShadow:'0 0 8px '+clr+'60'}}/>`}
+                </div>
+                <div class="w-10 text-[0.82rem] mono text-white text-right font-bold">${val?fm(val):'ERR'}</div>
+              </div>`)}
+            </div>
+          </div>`)}
+        </div>
+      </div>
+    </div>
+  </div>`;
+}
+
+/* ── APIs ── */
+function PApis(){
+  const [filt,setFilt]=useState('TODAS');
+  const cats=['TODAS','CONTROL','INPUT','SENSORS','MEDIA','APP','QUERIES','DEVICE','SCRIPT'];
+  const list=filt==='TODAS'?CAPS:CAPS.filter(c=>c.c===filt);
+  return h`<div class="h-full flex flex-col gap-4 fi">
+    <div class="grid grid-cols-3 gap-5 shrink-0">
+      ${TK.map(k=>{const s=S[k];const cnt=CAPS.filter(c=>c[k]===1).length;const p=CAPS.filter(c=>c[k]===2).length;return h`<div key=${k} class="bg-slate-900/60 border border-slate-800 p-6 rounded-[2rem] relative overflow-hidden group">
+        <div class="absolute -right-4 -bottom-4 text-slate-800/20 text-8xl opacity-40 group-hover:scale-110 transition-transform">🔌</div>
+        <div class="relative z-10">
+          <p class="text-[0.82rem] font-black uppercase tracking-[0.2em] mb-1" style=${{color:s.color}}>${s.name} APIs</p>
+          <div class="flex items-baseline gap-2"><h3 class="text-5xl font-black text-white italic">${cnt}</h3>${p>0&&h`<span class="text-xl font-bold text-amber-400">+${p}</span>`}</div>
+          <p class="text-[0.875rem] text-slate-500 mt-2 font-medium italic">de ${CAPS.length} funciones evaluadas</p>
+        </div>
+      </div>`})}
+    </div>
+    <div class="flex-1 min-h-0 bg-slate-900/50 border border-slate-800 rounded-[2rem] overflow-hidden flex flex-col">
+      <div class="px-6 py-3 bg-slate-900 border-b border-slate-800 flex gap-2 flex-wrap shrink-0">
+        ${cats.map(f=>h`<button key=${f} onClick=${()=>setFilt(f)} class="${'px-3 py-1.5 rounded-xl text-[0.82rem] font-black uppercase tracking-tighter border transition-all '+(filt===f?'bg-indigo-600 border-indigo-500 text-white':'bg-slate-900 border-slate-800 text-slate-500 hover:text-slate-200')}">${f}</button>`)}
+      </div>
+      <div class="flex-1 overflow-auto scr">
+        <table class="w-full text-[0.94rem]"><thead class="sticky top-0 bg-slate-900/95 z-10 text-slate-500 uppercase font-black border-b border-slate-800/50">
+          <tr><th class="px-6 py-3 text-left">Capacidad API</th><th class="px-3 py-3 text-center w-14">AP</th><th class="px-3 py-3 text-center w-14">MA</th><th class="px-3 py-3 text-center w-14">WDA</th></tr>
+        </thead><tbody class="divide-y divide-slate-800/30">
+          ${list.map((r,i)=>h`<tr key=${i} class="hover:bg-slate-800/20 transition-colors">
+            <td class="px-6 py-2 font-bold text-slate-300">${r.n} <span class="text-[0.94rem] bg-slate-800 px-1.5 py-0.5 rounded text-slate-600 uppercase tracking-tighter ml-1">${r.c}</span></td>
+            <td class="px-3 py-2 text-center"><${Chk} v=${r.ap} c=${S.ap.color}/></td>
+            <td class="px-3 py-2 text-center"><${Chk} v=${r.ma} c=${S.ma.color}/></td>
+            <td class="px-3 py-2 text-center"><${Chk} v=${r.wda} c=${S.wda.color}/></td>
+          </tr>`)}
+        </tbody></table>
+      </div>
+    </div>
+  </div>`;
+}
+
+/* ── Architecture ── */
+function PArch(){
+  return h`<div class="h-full grid grid-cols-3 gap-6 fi">
+    ${TK.map(k=>{const s=S[k];return h`<div key=${k} class="bg-slate-900/40 border border-slate-800 rounded-[2rem] p-7 flex flex-col gap-5">
+      <div class="flex items-center gap-3 border-b border-slate-800 pb-4">
+        <div class="p-3 rounded-2xl shadow-xl" style=${{background:s.color+'15'}}>📦</div>
+        <div><h3 class="text-lg font-black text-white uppercase italic tracking-tighter leading-none">${s.name}</h3><p class="text-[0.82rem] text-slate-500 font-bold uppercase mt-1">${s.protocol}</p></div>
+      </div>
+      <p class="text-[0.94rem] text-slate-400 leading-relaxed">${s.archDesc}</p>
+      <div class="space-y-3 flex-1 flex flex-col justify-center">
+        ${s.layers.map((l,i)=>h`<div key=${i}>
+          <div class="p-4 bg-slate-950 border border-slate-800 rounded-xl text-[0.875rem] font-black uppercase text-slate-400 text-center hover:border-indigo-500/50 transition-colors">${l}</div>
+          ${i<s.layers.length-1&&h`<div class="flex justify-center"><div class="w-px h-3 bg-slate-800"/></div>`}
+        </div>`)}
+      </div>
+      <div class="space-y-2 pt-4 border-t border-slate-800">
+        ${[["Post-tap",s.postTap],["Búsqueda",s.search],["Retry",s.retry]].map(([l,v])=>h`<div key=${l} class="flex justify-between text-[0.82rem]"><span class="text-slate-600 font-bold uppercase">${l}</span><span class="text-slate-400 font-bold">${v}</span></div>`)}
+      </div>
+    </div>`})}
+  </div>`;
+}
+
+/* ── Timeline (RACE) ── */
+function PTimeline(){
+  const [flow,setFlow]=useState('login');
+  const [prog,setProg]=useState({ap:0,ma:0,wda:0});
+  const [racing,setRacing]=useState(false);
+  const raf=useRef(null);
+  const t0=useRef(null);
+
+  const speeds=flow==='login'?{ap:2.0,ma:0.85,wda:1.7}:{ap:2.8,ma:0,wda:2.0};
+
+  useEffect(()=>{
+    if(!racing)return;
+    t0.current=Date.now();
+    const tick=()=>{
+      const el=(Date.now()-t0.current)/1000;
+      const next={ap:Math.min(el*speeds.ap*10,100),ma:speeds.ma===0?100:Math.min(el*speeds.ma*10,100),wda:Math.min(el*speeds.wda*10,100)};
+      setProg(next);
+      if(el<12)raf.current=requestAnimationFrame(tick);else setRacing(false);
+    };
+    raf.current=requestAnimationFrame(tick);
+    return()=>{if(raf.current)cancelAnimationFrame(raf.current)};
+  },[racing]);
+
+  const startRace=()=>{setProg({ap:0,ma:0,wda:0});setTimeout(()=>setRacing(true),50)};
+  const switchFlow=(f)=>{setFlow(f);setProg({ap:0,ma:0,wda:0});setRacing(false)};
+
+  const steps=flow==='login'?TL_LOGIN:TL_BIO;
+
+  return h`<div class="h-full flex flex-col gap-4 fi">
+    <div class="flex justify-between items-center bg-slate-900/50 p-5 rounded-[2rem] border border-slate-800 shrink-0">
+      <div class="flex items-center gap-4">
+        <div class="p-3 bg-indigo-600/10 rounded-xl border border-indigo-600/20 text-indigo-400 text-xl">⏱</div>
+        <div>
+          <h2 class="text-lg font-black text-white uppercase italic tracking-tighter">Comparativa de Ejecución</h2>
+          <p class="text-[0.82rem] text-slate-500 font-bold uppercase tracking-widest italic">${flow==='login'?'Login Flow — PIN + Navegación':'Biometric Flow — Face ID'}</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <div class="flex bg-slate-950 p-1 rounded-xl border border-slate-800">
+          <button onClick=${()=>switchFlow('login')} class="${'px-4 py-2 rounded-lg text-[0.875rem] font-black uppercase tracking-tighter transition-all '+(flow==='login'?'bg-indigo-600 text-white':'text-slate-500 hover:text-white')}">🔑 Login</button>
+          <button onClick=${()=>switchFlow('bio')} class="${'px-4 py-2 rounded-lg text-[0.875rem] font-black uppercase tracking-tighter transition-all '+(flow==='bio'?'bg-indigo-600 text-white':'text-slate-500 hover:text-white')}">🛡 Biometric</button>
+        </div>
+        <button onClick=${startRace} class="flex items-center gap-2 px-6 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl font-black uppercase text-xs transition-all shadow-xl active:scale-95">
+          ${prog.ap>0?'↺ REINICIAR':'▶ INICIAR CARRERA'}
+        </button>
+      </div>
+    </div>
+    <div class="flex-1 grid grid-cols-3 gap-6 min-h-0">
+      ${TK.map(k=>{
+        const s=S[k];const p=prog[k];const st=steps[k];
+        const idx=Math.min(st.length-1,Math.floor((p/100)*st.length));
+        const step=st[idx];
+        const total=flow==='login'?s.login:s.bio;
+        return h`<div key=${k} class="flex flex-col items-center gap-3 min-h-0">
+          <div class="w-full shrink-0">
+            <div class="flex justify-between items-center px-1 mb-1.5">
+              <span class="text-[0.875rem] font-black text-white uppercase italic tracking-widest">${s.name}</span>
+              <span class="text-[0.875rem] mono font-bold" style=${{color:s.color}}>${!total?'✗ N/A':p>=100?'✓ '+fm(total):p.toFixed(0)+'%'}</span>
+            </div>
+            <div class="h-1.5 w-full bg-slate-900 rounded-full overflow-hidden flex gap-0.5 p-0.5 border border-slate-800">
+              ${st.map((_,i)=>h`<div key=${i} class="h-full flex-1 rounded-full transition-all duration-300" style=${{background:p>(i/st.length)*100?(!total?'#ef4444':s.color):'#1e293b',boxShadow:p>(i/st.length)*100&&total?'0 0 8px '+s.color+'60':'none'}}/>`)}
+            </div>
+            <div class="flex justify-between items-center px-1 mt-1.5 h-5">
+              <span class="text-[0.82rem] font-black uppercase tracking-widest transition-all duration-300" style=${{color:!total?'#ef4444':s.color}}>${step.label}</span>
+              <span class="text-[0.82rem] mono text-slate-600 font-bold">${step.time}</span>
+            </div>
+          </div>
+          <div class="w-full max-w-[200px] relative flex-1 min-h-0 flex items-center">
+            <div class="w-full"><${Phone} img=${step.img}/></div>
+            <div class="absolute -right-2 top-1/4 bg-slate-900 border border-slate-800 p-3 rounded-xl shadow-2xl z-30 max-w-[130px] transition-all duration-300" style=${{borderColor:(!total?'#ef4444':s.color)+'30'}}>
+              <p class="text-[0.94rem] font-black uppercase tracking-widest mb-0.5" style=${{color:!total?'#ef4444':s.color}}>${step.label}</p>
+              <p class="text-[0.82rem] text-slate-300 font-bold leading-tight">${step.detail}</p>
+              <div class="mt-2 flex items-center justify-between text-[0.75rem] mono font-bold text-slate-600 uppercase border-t border-slate-800 pt-1.5"><span>Time</span><span>${step.time}</span></div>
+            </div>
+          </div>
+          <div class="text-center shrink-0">
+            <p class="text-xs font-black text-white uppercase italic">${total?fm(total)+' TOTAL':'N/A'}</p>
+            <p class="text-[0.75rem] text-slate-600 font-bold uppercase tracking-widest italic">${s.protocol}</p>
+          </div>
+        </div>`;
+      })}
+    </div>
+  </div>`;
+}
+
+/* ── Scripts ── */
+function PScripts(){
+  return h`<div class="h-full grid grid-cols-3 gap-5 fi">
+    ${TK.map(k=>{const s=S[k];const sc=SCRIPTS[k];return h`<div key=${k} class="bg-slate-900 border border-slate-800 rounded-[2rem] overflow-hidden flex flex-col shadow-2xl">
+      <div class="px-6 py-4 border-b border-slate-800 bg-slate-900/80 flex items-center justify-between shrink-0">
+        <div class="flex items-center gap-2"><div class="p-1.5 rounded-lg" style=${{background:s.color+'15'}}>📄</div><span class="text-xs font-black text-white uppercase italic tracking-tighter">${s.name} Logic</span></div>
+        <div class="px-2 py-0.5 bg-slate-950 border border-slate-800 rounded text-[0.82rem] mono text-slate-500 font-bold">${s.loc} LOC</div>
+      </div>
+      <div class="flex-1 p-5 bg-slate-950 overflow-auto scr"><${Syntax} code=${sc.code} lang=${sc.lang}/></div>
+      <div class="p-4 bg-slate-900 border-t border-slate-800 shrink-0">
+        <div class="flex gap-3">
+          <div class="flex-1 p-2.5 bg-slate-950/50 rounded-lg border border-slate-800"><p class="text-[0.94rem] text-slate-600 font-black uppercase mb-0.5">Paradigma</p><p class="text-[0.82rem] text-slate-400 font-bold italic">${k==='ap'?'Declarativo (Nativo)':k==='ma'?'YAML (Simulación)':'Imperativo (W3C)'}</p></div>
+          <div class="flex-1 p-2.5 bg-slate-950/50 rounded-lg border border-slate-800"><p class="text-[0.94rem] text-slate-600 font-black uppercase mb-0.5">Validación</p><p class="text-[0.82rem] text-slate-400 font-bold italic">${k==='ap'?'AX Memory Poll':k==='ma'?'Retry Tree Walk':'HTTP Predicate'}</p></div>
+        </div>
+      </div>
+    </div>`})}
+  </div>`;
+}
+
+/* ── Roadmap ── */
+function PRoad(){
+  return h`<div class="h-full fi">
+    <div class="h-full grid grid-cols-4 gap-4 overflow-auto scr">
+      ${ROAD.map((r,i)=>h`<div key=${i} class="${'bg-slate-900/40 border rounded-[1.5rem] p-6 flex flex-col group hover:border-indigo-500/50 transition-all shadow-xl '+(r.status==='ARCHIVED'?'border-slate-800 opacity-60':'border-slate-800')}">
+        <div class="flex justify-between items-start mb-4">
+          <div class="p-2 bg-indigo-500/10 text-indigo-500 rounded-xl group-hover:scale-110 transition-transform">🎯</div>
+          <span class="${'text-[0.94rem] font-black px-2 py-0.5 rounded uppercase tracking-widest '+(r.status==='IN PROGRESS'?'bg-emerald-500/10 text-emerald-400':'bg-slate-800 text-slate-400')}">${r.status}</span>
+        </div>
+        <h3 class="text-sm font-black text-white uppercase italic tracking-tighter mb-1">${r.title}</h3>
+        <p class="text-[0.875rem] text-slate-500 leading-relaxed mb-4 flex-1">${r.desc}</p>
+        <div class="space-y-2 pt-3 border-t border-slate-800/50">
+          <div class="flex justify-between text-[0.75rem] font-bold uppercase tracking-widest"><span class="text-slate-600">Prioridad</span><span class="${r.priority==='CRÍTICA'?'text-red-500':r.priority==='ALTA'?'text-amber-400':'text-slate-400'}">${r.priority}</span></div>
+          <div class="flex justify-between text-[0.75rem] font-bold uppercase tracking-widest"><span class="text-slate-600">Dificultad</span><span class="text-slate-400">${r.difficulty}</span></div>
+        </div>
+      </div>`)}
+    </div>
+  </div>`;
+}
+
+/* ═══════════ MAIN ═══════════ */
+
+function App(){
+  const [tab,setTab]=useState('overview');
+  const pages={overview:POverview,apis:PApis,arch:PArch,timeline:PTimeline,scripts:PScripts,roadmap:PRoad};
+  const Page=pages[tab];
+
+  return h`<div class="h-screen flex flex-col overflow-hidden">
+    <nav class="shrink-0 px-6 py-4 border-b border-slate-900 flex justify-between items-center">
+      <div class="flex items-center gap-4">
+        <div class="flex items-center gap-2"><span class="text-emerald-500 text-xl">⚡</span><h1 class="text-xl font-black text-white tracking-tighter uppercase italic">AutoPilot <span class="text-slate-700">Lab</span></h1></div>
+        <div class="h-4 w-px bg-slate-800"/>
+        <p class="text-[0.82rem] text-slate-500 font-bold uppercase tracking-widest italic hidden md:block">iPhone 16 Pro (iOS 26.3) — Real Data</p>
+        <div class="hidden md:flex gap-1.5">${TK.map(k=>h`<span key=${k} class="text-[0.94rem] font-black px-1.5 py-0.5 rounded border uppercase tracking-tighter" style=${{background:S[k].color+'08',borderColor:S[k].color+'25',color:S[k].color}}>${S[k].name} ${S[k].status}</span>`)}</div>
+      </div>
+      <div class="flex bg-slate-900/80 p-1 rounded-2xl border border-slate-800 overflow-hidden shadow-2xl">
+        ${TABS.map(t=>h`<button key=${t.id} onClick=${()=>setTab(t.id)} class="${'flex items-center gap-2 px-4 py-2.5 rounded-xl text-[0.875rem] font-black uppercase tracking-tighter transition-all '+(tab===t.id?'bg-indigo-600 text-white shadow-xl scale-105':'text-slate-500 hover:text-slate-300 hover:bg-slate-800')}"><span>${t.icon}</span> ${t.label}</button>`)}
+      </div>
+    </nav>
+    <main class="flex-1 p-5 min-h-0"><${Page}/></main>
+    <footer class="shrink-0 bg-slate-950/80 border-t border-slate-900 py-2 px-6 flex justify-between items-center">
+      <div class="flex items-center gap-6">
+        <div class="flex items-center gap-2"><div class="w-2 h-2 rounded-full bg-emerald-500 animate-pulse" style=${{boxShadow:'0 0 10px rgba(16,185,129,.5)'}}/><span class="text-[0.875rem] font-black text-slate-300 uppercase tracking-widest italic">Engine: ONLINE</span></div>
+        <div class="h-3 w-px bg-slate-800"/>
+        <span class="text-[0.82rem] font-bold text-slate-600 uppercase tracking-widest">v3.1 stable</span>
+      </div>
+      <span class="text-[0.82rem] font-black text-slate-700 uppercase tracking-[0.2em] italic hidden md:block">AutoPilot Lab Benchmark — ${new Date().toISOString().split('T')[0]}</span>
+    </footer>
+  </div>`;
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(h`<${App}/>`);
+</script>
+</body>
+</html>

--- a/scripts/benchmark-suite/report/generate-html.py
+++ b/scripts/benchmark-suite/report/generate-html.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Generate HTML benchmark report from JSONL results + evidence screenshots."""
+import json, sys, os, glob, datetime, base64
+from collections import defaultdict
+
+results_file = sys.argv[1] if len(sys.argv) > 1 else "benchmark-results/all-results.jsonl"
+evidence_dir = sys.argv[2] if len(sys.argv) > 2 else "evidence"
+output_file = sys.argv[3] if len(sys.argv) > 3 else "benchmark-results/benchmark-report.html"
+
+# Parse results
+data = defaultdict(list)
+failures = defaultdict(int)
+
+with open(results_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line: continue
+        r = json.loads(line)
+        key = (r["tool"], r["test"])
+        if r["exit_code"] == 0:
+            data[key].append(r["total_ms"])
+        else:
+            failures[key] += 1
+
+def stats(values):
+    if not values:
+        return {"min": 0, "avg": 0, "max": 0, "p95": 0, "n": 0}
+    values = sorted(values)
+    n = len(values)
+    p95_idx = min(int(n * 0.95), n - 1)
+    return {
+        "min": values[0],
+        "avg": int(sum(values) / n),
+        "max": values[-1],
+        "p95": values[p95_idx],
+        "n": n
+    }
+
+def fmt_ms(ms):
+    if ms == 0: return "N/A"
+    if ms >= 1000: return f"{ms/1000:.1f}s"
+    return f"{ms}ms"
+
+def img_to_base64(path):
+    if not os.path.exists(path): return None
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode()
+
+tests = sorted(set(t for _, t in data.keys()))
+tools = ["autopilot", "maestro", "wda"]
+tool_colors = {"autopilot": "#FF6B6B", "maestro": "#4ECDC4", "wda": "#9B59B6"}
+tool_labels = {"autopilot": "AutoPilot", "maestro": "Maestro", "wda": "WDA"}
+
+now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+# Find screenshots
+screenshots = defaultdict(lambda: defaultdict(list))
+for f in sorted(glob.glob(os.path.join(evidence_dir, "*.png"))):
+    name = os.path.basename(f)
+    parts = name.replace(".png", "").split("-")
+    if len(parts) >= 3:
+        tool = parts[0]
+        test = parts[1]
+        screenshots[test][tool].append(f)
+
+# Build HTML
+html = []
+html.append(f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<title>Benchmark: AutoPilot vs Maestro vs WDA</title>
+<style>
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ font: 14px/1.6 -apple-system, system-ui, sans-serif; background: #0f0f1a; color: #e0e0e0; padding: 40px; }}
+  h1 {{ font-size: 28px; margin-bottom: 8px; color: #fff; }}
+  h2 {{ font-size: 20px; margin: 32px 0 16px; color: #fff; }}
+  h3 {{ font-size: 16px; margin: 24px 0 12px; color: #ccc; }}
+  .subtitle {{ color: #888; margin-bottom: 32px; }}
+  .callout {{ background: #1a1a2e; border-left: 4px solid #f39c12; padding: 12px 16px; margin: 16px 0; border-radius: 4px; }}
+  table {{ width: 100%; border-collapse: collapse; margin: 16px 0; }}
+  th {{ background: #1a1a2e; padding: 10px 12px; text-align: left; font-weight: 600; border-bottom: 2px solid #333; }}
+  td {{ padding: 10px 12px; border-bottom: 1px solid #222; }}
+  .winner {{ background: rgba(46, 204, 113, 0.15); font-weight: bold; }}
+  .na {{ color: #666; font-style: italic; }}
+  .tool-badge {{ display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; color: #fff; }}
+  .screenshots {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; margin: 16px 0; }}
+  .screenshot-card {{ background: #1a1a2e; border-radius: 8px; overflow: hidden; }}
+  .screenshot-card img {{ width: 100%; height: auto; }}
+  .screenshot-card .label {{ padding: 8px 12px; font-size: 12px; color: #aaa; }}
+  .summary {{ background: #1a1a2e; border-radius: 8px; padding: 20px; margin: 24px 0; }}
+  .summary strong {{ color: #2ecc71; }}
+</style>
+</head><body>
+<h1>Benchmark Suite</h1>
+<p class="subtitle">AutoPilot vs Maestro vs WDA &mdash; {now}</p>
+""")
+
+# Summary table per test
+for test in tests:
+    html.append(f"<h2>Test: {test}</h2>")
+
+    test_tools = tools if test != "biometric" else ["autopilot", "wda"]
+
+    if test == "biometric":
+        html.append('<div class="callout">Maestro no soporta biometric nativo. Su sandbox JS no permite ejecutar comandos del sistema (xcrun simctl). <a href="https://github.com/mobile-dev-inc/maestro/issues/1075" style="color:#3498db">#1075</a></div>')
+
+    html.append("<table><tr><th>Metric</th>")
+    for tool in test_tools:
+        color = tool_colors[tool]
+        html.append(f'<th><span class="tool-badge" style="background:{color}">{tool_labels[tool]}</span></th>')
+    html.append("</tr>")
+
+    s = {}
+    for tool in test_tools:
+        s[tool] = stats(data.get((tool, test), []))
+
+    # Find winner (lowest avg with at least 1 run)
+    valid = {t: s[t]["avg"] for t in test_tools if s[t]["n"] > 0}
+    winner = min(valid, key=valid.get) if valid else None
+
+    for metric in ["min", "avg", "max", "p95"]:
+        html.append(f"<tr><td>{metric.upper()}</td>")
+        for tool in test_tools:
+            val = s[tool][metric]
+            cls = ' class="winner"' if tool == winner else ''
+            if s[tool]["n"] == 0:
+                html.append(f'<td class="na">N/A (failed)</td>')
+            else:
+                html.append(f"<td{cls}>{fmt_ms(val)}</td>")
+        html.append("</tr>")
+
+    # Runs row
+    html.append("<tr><td>Runs (ok/fail)</td>")
+    for tool in test_tools:
+        ok = s[tool]["n"]
+        fail = failures.get((tool, test), 0)
+        html.append(f"<td>{ok}/{fail}</td>")
+    html.append("</tr></table>")
+
+    # Screenshots
+    if any(screenshots[test].get(t) for t in test_tools):
+        html.append("<h3>Evidence</h3><div class='screenshots'>")
+        max_steps = max(len(screenshots[test].get(t, [])) for t in test_tools)
+        for step in range(max_steps):
+            for tool in test_tools:
+                imgs = screenshots[test].get(tool, [])
+                if step < len(imgs):
+                    b64 = img_to_base64(imgs[step])
+                    if b64:
+                        name = os.path.basename(imgs[step])
+                        color = tool_colors[tool]
+                        html.append(f'<div class="screenshot-card"><img src="data:image/png;base64,{b64}"/><div class="label"><span class="tool-badge" style="background:{color}">{tool_labels[tool]}</span> {name}</div></div>')
+        html.append("</div>")
+
+# Overall summary
+html.append('<div class="summary"><h2>Summary</h2>')
+for test in tests:
+    test_tools = tools if test != "biometric" else ["autopilot", "wda"]
+    valid = {t: stats(data.get((t, test), []))["avg"] for t in test_tools if stats(data.get((t, test), []))["n"] > 0}
+    if valid:
+        winner = min(valid, key=valid.get)
+        winner_ms = valid[winner]
+        others = {t: v for t, v in valid.items() if t != winner}
+        comparisons = []
+        for t, v in others.items():
+            if winner_ms > 0:
+                speedup = v / winner_ms
+                comparisons.append(f"{speedup:.1f}x vs {tool_labels[t]}")
+        html.append(f"<p><strong>{tool_labels[winner]}</strong> wins <strong>{test}</strong> ({fmt_ms(winner_ms)} avg) &mdash; {', '.join(comparisons)}</p>")
+html.append("</div>")
+
+html.append("</body></html>")
+
+os.makedirs(os.path.dirname(output_file), exist_ok=True)
+with open(output_file, "w") as f:
+    f.write("\n".join(html))
+
+print(f"Report: {output_file}")

--- a/scripts/benchmark-suite/run.sh
+++ b/scripts/benchmark-suite/run.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SUITE_DIR/../.." && pwd)"
+export RESULTS_DIR="$SUITE_DIR/benchmark-results"
+export EVIDENCE_DIR="$SUITE_DIR/evidence"
+TOOLS_DIR="$SUITE_DIR/tools"
+export TOTAL_RUNS="${TOTAL_RUNS:-11}"
+
+# Source libraries
+source "$SUITE_DIR/lib/timing.sh"
+source "$SUITE_DIR/lib/screenshots.sh"
+source "$SUITE_DIR/lib/simulator.sh"
+source "$SUITE_DIR/lib/tools-setup.sh"
+
+echo "╔══════════════════════════════════════════╗"
+echo "║  Benchmark: AutoPilot vs Maestro vs WDA      ║"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+# 1. Create directories
+mkdir -p "$RESULTS_DIR" "$EVIDENCE_DIR" "$TOOLS_DIR"
+rm -f "$RESULTS_DIR"/*.jsonl "$EVIDENCE_DIR"/*.png
+
+# 2. Setup tools
+setup_tools "$TOOLS_DIR" "$PROJECT_ROOT"
+
+# 3. Simulator
+ensure_simulator_booted
+ensure_app_installed "$PROJECT_ROOT"
+
+# 4. Verify WDA is running (checked by setup_tools)
+
+# Symlink evidence dir so relative paths from auto/maestro scripts work
+ln -sfn "$EVIDENCE_DIR" "$PROJECT_ROOT/evidence"
+
+echo ""
+echo "=== Running benchmarks ==="
+echo ""
+
+# 5. Login test: all 3 tools
+run_benchmark "autopilot" "login" \
+  "$TOOLS_DIR/auto" run "$SUITE_DIR/tests/login.auto"
+
+MAESTRO_CLI_NO_ANALYTICS=1 MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true \
+run_benchmark "maestro" "login" \
+  "$TOOLS_DIR/maestro" test --platform ios "$SUITE_DIR/tests/login.yaml"
+
+run_benchmark "wda" "login" \
+  node "$SUITE_DIR/tests/login.js"
+
+# 6. Biometric test: AutoPilot + WDA (Maestro cannot)
+run_benchmark "autopilot" "biometric" \
+  "$TOOLS_DIR/auto" run "$SUITE_DIR/tests/biometric.auto"
+
+run_benchmark "wda" "biometric" \
+  node "$SUITE_DIR/tests/biometric.js"
+
+# 7. Merge JSONL
+cat "$RESULTS_DIR"/*.jsonl > "$RESULTS_DIR/all-results.jsonl" 2>/dev/null || true
+
+# 9. Generate HTML report
+python3 "$SUITE_DIR/report/generate-html.py" \
+  "$RESULTS_DIR/all-results.jsonl" \
+  "$EVIDENCE_DIR" \
+  "$RESULTS_DIR/benchmark-report.html"
+
+echo ""
+echo "╔══════════════════════════════════════════╗"
+echo "║  Suite complete!                            ║"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+echo "Report: $RESULTS_DIR/benchmark-report.html"
+
+# 10. Copy comparison dashboard
+cp "$SUITE_DIR/report/comparison-dashboard.html" "$RESULTS_DIR/comparison-dashboard.html"
+
+# 11. Open reports
+open "$RESULTS_DIR/comparison-dashboard.html" 2>/dev/null || true
+echo "Dashboard: $RESULTS_DIR/comparison-dashboard.html"

--- a/scripts/benchmark-suite/tests/appium-helpers.js
+++ b/scripts/benchmark-suite/tests/appium-helpers.js
@@ -1,0 +1,150 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const WDA_PORT = process.env.WDA_PORT || 8100;
+const BASE_URL = `http://127.0.0.1:${WDA_PORT}`;
+const BUNDLE_ID = 'dev.autopilot.test.Explorea';
+const EVIDENCE_DIR = process.env.EVIDENCE_DIR || 'evidence';
+const EVIDENCE_PREFIX = process.env.EVIDENCE_PREFIX || 'wda';
+
+async function request(method, urlPath, body) {
+  const opts = { method, headers: { 'Content-Type': 'application/json' } };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(`${BASE_URL}${urlPath}`, opts);
+  const text = await res.text();
+  try { return JSON.parse(text); }
+  catch { return text; }
+}
+
+async function createSession() {
+  const res = await request('POST', '/session', {
+    capabilities: { alwaysMatch: { bundleId: BUNDLE_ID } },
+  });
+  if (!res.value || !res.value.sessionId) {
+    throw new Error('Failed to create session: ' + JSON.stringify(res));
+  }
+  return res.value.sessionId;
+}
+
+async function deleteSession(sessionId) {
+  await request('DELETE', `/session/${sessionId}`);
+}
+
+async function findElement(sessionId, text) {
+  const res = await request('POST', `/session/${sessionId}/element`, {
+    using: 'predicate string',
+    value: `label == "${text}" OR name == "${text}"`,
+  });
+  if (!res.value || !res.value.ELEMENT) {
+    const el = res.value && Object.values(res.value)[0];
+    if (!el) throw new Error(`Element not found: ${text}`);
+    return el;
+  }
+  return res.value.ELEMENT;
+}
+
+async function tapElement(sessionId, elementId) {
+  await request('POST', `/session/${sessionId}/element/${elementId}/click`);
+}
+
+async function findAndTap(sessionId, text) {
+  const elementId = await findElement(sessionId, text);
+  await tapElement(sessionId, elementId);
+}
+
+async function waitForElement(sessionId, text, timeoutMs = 10000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      return await findElement(sessionId, text);
+    } catch {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  throw new Error(`Timeout waiting for: ${text}`);
+}
+
+async function saveScreenshot(sessionId, filename) {
+  const res = await request('GET', `/session/${sessionId}/screenshot`);
+  if (res.value) {
+    const buffer = Buffer.from(res.value, 'base64');
+    const filePath = path.resolve(filename);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, buffer);
+  }
+}
+
+// Biometric via Simulator menu (AppleScript) — same approach as AutoPilot CLI.
+// WDA and simctl have no biometric endpoints on Xcode 26.
+function biometricIsEnrolled() {
+  const script = `
+    tell application "System Events" to tell process "Simulator"
+      set enrolledItem to menu item "Enrolled" of menu "Face ID" of menu item "Face ID" of menu "Features" of menu bar 1
+      set m to value of attribute "AXMenuItemMarkChar" of enrolledItem
+      if m is missing value then return "false"
+      return "true"
+    end tell`;
+  const out = execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, { encoding: 'utf8' }).trim();
+  return out === 'true';
+}
+
+function clickSimulatorMenu(menuItem) {
+  const script = `tell application "System Events" to tell process "Simulator" to click menu item "${menuItem}" of menu "Face ID" of menu item "Face ID" of menu "Features" of menu bar 1`;
+  // Activate Simulator first so menu is accessible
+  execSync('osascript -e \'tell application "Simulator" to activate\'', { stdio: 'ignore' });
+  execSync(`osascript -e '${script}'`, { stdio: 'ignore' });
+}
+
+function enrollBiometric(enabled = true) {
+  const enrolled = biometricIsEnrolled();
+  if (enabled && !enrolled) {
+    clickSimulatorMenu('Enrolled');
+  } else if (!enabled && enrolled) {
+    clickSimulatorMenu('Enrolled');
+  }
+}
+
+function sendBiometricMatch(match = true) {
+  const item = match ? 'Matching Face' : 'Non-matching Face';
+  clickSimulatorMenu(item);
+}
+
+async function terminateApp(sessionId) {
+  await request('POST', `/session/${sessionId}/wda/apps/terminate`, {
+    bundleId: BUNDLE_ID,
+  });
+}
+
+async function activateApp(sessionId) {
+  await request('POST', `/session/${sessionId}/wda/apps/launch`, {
+    bundleId: BUNDLE_ID,
+  });
+}
+
+async function swipeUp(sessionId) {
+  // WDA swipe via touch actions
+  const winSize = await request('GET', `/session/${sessionId}/window/size`);
+  const w = winSize.value.width;
+  const h = winSize.value.height;
+  await request('POST', `/session/${sessionId}/wda/touch/perform`, {
+    actions: [
+      { action: 'press', options: { x: w / 2, y: h * 0.7 } },
+      { action: 'wait', options: { ms: 200 } },
+      { action: 'moveTo', options: { x: w / 2, y: h * 0.3 } },
+      { action: 'release' },
+    ],
+  });
+}
+
+async function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+module.exports = {
+  createSession, deleteSession,
+  findAndTap, waitForElement, saveScreenshot,
+  enrollBiometric, sendBiometricMatch,
+  terminateApp, activateApp, swipeUp, sleep,
+  EVIDENCE_DIR, EVIDENCE_PREFIX, BUNDLE_ID,
+};

--- a/scripts/benchmark-suite/tests/biometric.auto
+++ b/scripts/benchmark-suite/tests/biometric.auto
@@ -1,0 +1,13 @@
+# Benchmark: Biometric flow
+# Con screenshots como evidencia
+
+ping
+biometric unenroll
+biometric enroll
+terminate dev.autopilot.test.Explorea
+launch dev.autopilot.test.Explorea
+waitFor "Desbloquear con biometría" 10
+screenshot evidence/autopilot-biometric-step1.png
+tap "Desbloquear con biometría"
+biometric match
+screenshot evidence/autopilot-biometric-step2.png

--- a/scripts/benchmark-suite/tests/biometric.js
+++ b/scripts/benchmark-suite/tests/biometric.js
@@ -1,0 +1,41 @@
+const {
+  createSession, deleteSession,
+  findAndTap, waitForElement, saveScreenshot,
+  enrollBiometric, sendBiometricMatch,
+  terminateApp, activateApp, sleep,
+  EVIDENCE_DIR,
+} = require('./appium-helpers');
+
+async function main() {
+  const sessionId = await createSession();
+  try {
+    // Enroll Face ID via simctl
+    enrollBiometric(false);
+    enrollBiometric(true);
+    await saveScreenshot(sessionId, `${EVIDENCE_DIR}/wda-biometric-step1.png`);
+
+    // Restart app to pick up biometric enrollment
+    await terminateApp(sessionId);
+    await sleep(500);
+    await activateApp(sessionId);
+    await sleep(1000);
+
+    await waitForElement(sessionId, 'Desbloquear con biometría', 10000);
+    await saveScreenshot(sessionId, `${EVIDENCE_DIR}/wda-biometric-step2.png`);
+
+    await findAndTap(sessionId, 'Desbloquear con biometría');
+    await sleep(500);
+
+    // Send Face ID match via simctl
+    sendBiometricMatch(true);
+    await sleep(1500);
+    await saveScreenshot(sessionId, `${EVIDENCE_DIR}/wda-biometric-step3.png`);
+  } finally {
+    await deleteSession(sessionId);
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/scripts/benchmark-suite/tests/login.auto
+++ b/scripts/benchmark-suite/tests/login.auto
@@ -1,0 +1,19 @@
+# Benchmark: Login + navegacion
+# Con screenshots como evidencia
+
+launch dev.autopilot.test.Explorea
+waitFor "Explorea" 10
+screenshot evidence/autopilot-login-step1.png
+tap "Usar código"
+waitFor "Ingresa tu código" 5
+screenshot evidence/autopilot-login-step2.png
+tap "1"
+tap "2"
+tap "3"
+tap "4"
+tap "Confirmar"
+waitFor "Inicio" 5
+screenshot evidence/autopilot-login-step3.png
+tap "Aventura"
+swipe up
+screenshot evidence/autopilot-login-step4.png

--- a/scripts/benchmark-suite/tests/login.js
+++ b/scripts/benchmark-suite/tests/login.js
@@ -1,0 +1,43 @@
+const {
+  createSession, deleteSession,
+  findAndTap, waitForElement, saveScreenshot,
+  terminateApp, activateApp, sleep,
+  EVIDENCE_DIR,
+} = require('./appium-helpers');
+
+async function main() {
+  const sessionId = await createSession();
+  try {
+    // Clean launch
+    await terminateApp(sessionId);
+    await sleep(500);
+    await activateApp(sessionId);
+    await sleep(1000);
+
+    await waitForElement(sessionId, 'Explorea', 10000);
+    await saveScreenshot(sessionId, `${EVIDENCE_DIR}/wda-login-step1.png`);
+
+    await findAndTap(sessionId, 'Usar código');
+    await waitForElement(sessionId, 'Ingresa tu código', 5000);
+    await saveScreenshot(sessionId, `${EVIDENCE_DIR}/wda-login-step2.png`);
+
+    await findAndTap(sessionId, '1');
+    await findAndTap(sessionId, '2');
+    await findAndTap(sessionId, '3');
+    await findAndTap(sessionId, '4');
+    await findAndTap(sessionId, 'Confirmar');
+    await waitForElement(sessionId, 'Inicio', 5000);
+    await saveScreenshot(sessionId, `${EVIDENCE_DIR}/wda-login-step3.png`);
+
+    await findAndTap(sessionId, 'Aventura');
+    await sleep(500);
+    await saveScreenshot(sessionId, `${EVIDENCE_DIR}/wda-login-step4.png`);
+  } finally {
+    await deleteSession(sessionId);
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/scripts/benchmark-suite/tests/login.yaml
+++ b/scripts/benchmark-suite/tests/login.yaml
@@ -1,0 +1,26 @@
+appId: dev.autopilot.test.Explorea
+---
+# Benchmark: Login + navegacion (Maestro)
+
+- launchApp
+
+- assertVisible: "Explorea"
+- takeScreenshot: evidence/maestro-login-step1
+
+- tapOn: "Usar código"
+
+- assertVisible: "Ingresa tu código"
+- takeScreenshot: evidence/maestro-login-step2
+
+- tapOn: "1"
+- tapOn: "2"
+- tapOn: "3"
+- tapOn: "4"
+- tapOn: "Confirmar"
+
+- assertVisible: "Inicio"
+- takeScreenshot: evidence/maestro-login-step3
+
+- tapOn: "Aventura"
+- scroll
+- takeScreenshot: evidence/maestro-login-step4

--- a/scripts/benchmarks/biometric-helpers.js
+++ b/scripts/benchmarks/biometric-helpers.js
@@ -2,7 +2,7 @@
 // Maestro no tiene comandos nativos de biometric,
 // asi que usamos runScript con java.lang.Runtime
 
-const action = ENV.ACTION;
+const action = ACTION;
 
 if (action === 'unenroll') {
     java.lang.Runtime.getRuntime()

--- a/scripts/benchmarks/biometric.yaml
+++ b/scripts/benchmarks/biometric.yaml
@@ -17,9 +17,7 @@ appId: dev.autopilot.test.Explorea
 
 - launchApp
 
-- assertVisible:
-    text: "Desbloquear con biometría"
-    timeout: 10000
+- assertVisible: "Desbloquear con biometría"
 
 - tapOn: "Desbloquear con biometría"
 


### PR DESCRIPTION
## Summary

- Suite completa de benchmarks comparando AutoPilot, Maestro y WDA en iOS Simulator (iPhone 16 Pro)
- Dashboard interactivo con 6 tabs: Overview, APIs, Arquitectura, Timeline animado, Scripts con syntax highlighting, Roadmap
- Biometric via AppleScript (Maestro no soporta Face ID nativo)

## Resultados

| Test | AutoPilot | Maestro | WDA |
|------|-----------|---------|-----|
| Login flow | **10.2s** ★ | 26.1s | 11.7s |
| Biometric | **7.6s** ★ | ✗ N/A | 10.7s |

Maestro es ~2.5x más lento por wait-for-idle (~2s) después de cada tap — decisión de diseño, no limitación técnica.

## Archivos

| Ruta | Descripción |
|------|-------------|
| `scripts/benchmark-suite/run.sh` | Orquestador principal |
| `scripts/benchmark-suite/tests/` | Scripts login + biometric para los 3 tools |
| `scripts/benchmark-suite/lib/` | timing, simulator, screenshots, tools-setup |
| `scripts/benchmark-suite/report/comparison-dashboard.html` | Dashboard interactivo |
| `scripts/benchmark-suite/report/generate-html.py` | Generador HTML con stats |

## Test plan

- [x] `TOTAL_RUNS=3 ./scripts/benchmark-suite/run.sh` — completa sin errores
- [x] Login flow: los 3 tools pasan
- [x] Biometric flow: AutoPilot + WDA pasan, Maestro marcado como N/A
- [x] Dashboard abre con datos reales y screenshots de evidencia
- [x] Syntax highlighting correcto en los 3 lenguajes (.auto, YAML, JS)
- [x] Timeline animado muestra screenshots capturados
- [x] Texto responsive con `clamp(10px, 0.85vw, 16px)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)