### PR TITLE
fix: editor tree/inspect — missing PATH, AX perms, stale agent

### DIFF
--- a/agent/app/src/main/kotlin/dev/autopilot/agent/SocketServer.kt
+++ b/agent/app/src/main/kotlin/dev/autopilot/agent/SocketServer.kt
@@ -131,8 +131,8 @@ class SocketServer(
     }
 
     private fun handleTree(): String {
-        val root = uiAutomation.rootInActiveWindow
-            ?: return errorResponse("No active window")
+        val root = getRoot()
+            ?: return errorResponse("No active window — is an app open? Try restarting the agent.")
 
         val tree = TreeSerializer.serialize(root)
         root.recycle()
@@ -204,7 +204,7 @@ class SocketServer(
         val direction = params?.optString("direction", "") ?: return errorResponse("Missing direction")
 
         // Get screen size from root window bounds
-        val root = uiAutomation.rootInActiveWindow ?: return errorResponse("No active window")
+        val root = getRoot() ?: return errorResponse("No active window")
         val bounds = Rect()
         root.getBoundsInScreen(bounds)
         root.recycle()
@@ -386,9 +386,19 @@ class SocketServer(
 
     // ── Helpers ──────────────────────────────────────────
 
+    /** Gets rootInActiveWindow with retries (UiAutomation can temporarily lose connection). */
+    private fun getRoot(): AccessibilityNodeInfo? {
+        for (i in 0 until 5) {
+            val root = uiAutomation.rootInActiveWindow
+            if (root != null) return root
+            Thread.sleep(200)
+        }
+        return null
+    }
+
     /** Busca un nodo por text, content-desc, o resource-id. Recursivo. */
     private fun findNode(query: String): AccessibilityNodeInfo? {
-        val root = uiAutomation.rootInActiveWindow ?: return null
+        val root = getRoot() ?: return null
         val q = query.lowercase()
 
         // First pass: exact match

--- a/cli/Sources/AutoCore/BridgeError.swift
+++ b/cli/Sources/AutoCore/BridgeError.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum BridgeError: Error, CustomStringConvertible {
     case simulatorNotRunning
     case noWindow
+    case accessibilityNotTrusted
     case elementNotFound(String)
     case noFrame(String)
     case noBootedDevice
@@ -20,7 +21,8 @@ public enum BridgeError: Error, CustomStringConvertible {
     public var description: String {
         switch self {
         case .simulatorNotRunning: return "Simulator is not running. Open it first."
-        case .noWindow: return "No simulator window found"
+        case .noWindow: return "No simulator window found. Is the Simulator open?"
+        case .accessibilityNotTrusted: return "Accessibility permission denied. Grant access in: System Settings → Privacy & Security → Accessibility. Add Terminal (or the app running this command)."
         case .elementNotFound(let t): return "Element not found: '\(t)'"
         case .noFrame(let t): return "Element '\(t)' has no frame"
         case .noBootedDevice: return "No booted simulator. Run: xcrun simctl boot <device>"

--- a/cli/Sources/AutoLibiOS/SimulatorBridge.swift
+++ b/cli/Sources/AutoLibiOS/SimulatorBridge.swift
@@ -649,8 +649,9 @@ public final class SimulatorBridge {
 
         simulatorPID = simRunning.processIdentifier
 
-        // Activate to make AX tree available
-        simRunning.activate()
+        // Activate to make AX tree available (ignoring other apps ensures
+        // it works even when launched from editor/Tauri subprocesses)
+        simRunning.activate(options: .activateIgnoringOtherApps)
 
         let app = AXUIElementCreateApplication(simRunning.processIdentifier)
 
@@ -665,6 +666,10 @@ public final class SimulatorBridge {
             usleep(200_000)
         }
 
+        // If we got here, check if it's a permissions issue
+        if !AXIsProcessTrusted() {
+            throw BridgeError.accessibilityNotTrusted
+        }
         throw BridgeError.noWindow
     }
 


### PR DESCRIPTION
## Summary
Fixes #40 — `tree` and `inspect` commands fail from the editor with "No simulator window found" (iOS) and "No active window" (Android).

**Three root causes:**

- **Editor subprocess missing env vars** — Tauri doesn't inherit shell PATH/ANDROID_HOME, so `xcrun` and `adb` weren't found. Ported `extended_path()`, `android_home()`, improved `find_binary()` with .app bundle support, architecture triple scanning, and `which` fallback. Added verbose error messages for debugging.
- **iOS AX activation too weak** — `activate()` replaced with `activate(options: .activateIgnoringOtherApps)` for reliable Simulator activation from editor subprocesses. Added `AXIsProcessTrusted()` check with actionable error message when AX permissions are missing.
- **Android agent stale UiAutomation** — `rootInActiveWindow` returns null when UiAutomation loses connection after long idle. Added `getRoot()` helper with 5 retries (1s total) across `handleTree()`, `handleScreenshot()`, and `findNode()`.

## Files changed
| File | Change |
|------|--------|
| `editor/src-tauri/src/lib.rs` | PATH + ANDROID_HOME env, improved find_binary, verbose errors |
| `cli/Sources/AutoLibiOS/SimulatorBridge.swift` | activateIgnoringOtherApps + AX trust check |
| `cli/Sources/AutoCore/BridgeError.swift` | New `accessibilityNotTrusted` case |
| `agent/.../SocketServer.kt` | `getRoot()` with retry for stale UiAutomation |

## Test plan
- [x] `auto tree` works from terminal (iOS)
- [x] `auto-android tree` works from terminal (Android)
- [x] `auto-android tree` works from editor (Android)
- [ ] `auto tree` from editor requires AX permission for the `auto` binary (macOS limitation)
- [x] `auto ping` / `auto-android ping` unaffected
- [x] Swift CLI compiles clean
- [x] Android agent compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)