### PR TITLE
docs: README section for editor build flow (post-#72 fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,41 @@ $ auto run login.auto
 7 step(s) completed (5004ms)
 ```
 
+### Editor visual (Tauri + Monaco)
+
+Editor con autocomplete, tree inspector, recorder, y Play button para correr scripts `.auto` sin salir de la UI. Dos flujos: **dev** (hot reload) y **release** (`.app` instalable).
+
+**Setup inicial — una vez por maquina:**
+
+```bash
+cd editor && ./setup.sh
+```
+
+Detecta Node/Rust/Swift/ADB, instala lo que falte, corre `swift build` del CLI, y copia los binarios `auto` y `auto-android` a los dos lugares que Tauri necesita: `../{auto,auto-android}` (para `tauri dev`) y `src-tauri/binaries/auto-*-<target-triple>` (para `tauri build`, que los bundlea dentro del `.app`).
+
+**Dev — hot reload de React + rebuild automatico del Rust:**
+
+```bash
+cd editor && npm run tauri dev
+```
+
+**Release — generar `.app` e instalar:**
+
+```bash
+cd editor && npm run tauri build
+cp -r src-tauri/target/release/bundle/macos/AutoPilot\ Editor.app /Applications/
+```
+
+> **⚠ Cada vez que modifiques `cli/Sources/...` tenes que re-sincronizar los binarios del editor antes de rebuild.** Tauri bundlea desde `editor/src-tauri/binaries/` que NO se actualiza automaticamente cuando recompilas el CLI. Flujo correcto:
+>
+> ```bash
+> cd cli && swift build && cd ..
+> ./editor/refresh-binaries.sh        # copia el CLI fresco a binaries/
+> cd editor && npm run tauri build    # ahora bundlea el CLI actualizado
+> ```
+>
+> Sin este paso, el `.app` queda con la version anterior del `auto` binario y cualquier comando nuevo del CLI falla en el editor con `Unknown command: ...`. Fix permanente (hook post-build automatico) tracked en [#81](https://github.com/fsaldivar-dev/AutoPilot/issues/81).
+
 ---
 
 ## Alternativas


### PR DESCRIPTION
## Summary

Small follow-up to PR #72 (merged). A clean-machine user tried to build the editor via `tauri build` following the README and got `Unknown command: interactive` at runtime. Root cause: `editor/src-tauri/binaries/` is in `.gitignore`, so on a fresh checkout Tauri bundles stale or missing binaries.

The README had no section documenting the editor build flow — devs had no signal that `./editor/setup.sh` or `./editor/refresh-binaries.sh` was a prerequisite.

## What changed

Added a `### Editor visual (Tauri + Monaco)` subsection to the Inicio rápido block with three flows:

1. **Setup inicial (once per machine)**: `cd editor && ./setup.sh` — installs deps, builds CLI, copies binaries to both `../{auto,auto-android}` (tauri dev cwd-relative) and `src-tauri/binaries/auto-*-<target-triple>` (tauri build externalBin).
2. **Dev**: `npm run tauri dev`
3. **Release**: `npm run tauri build` + `cp` the `.app` to `/Applications/`.

Plus a warning blockquote with the exact three commands to re-sync binaries after any CLI change:

    cd cli && swift build && cd ..
    ./editor/refresh-binaries.sh
    cd editor && npm run tauri build

Linked to #81 which tracks the permanent fix (automatic post-build hook).

## Related

- Fixes a documentation gap discovered right after PR #72 merged
- Related to #81 (automatic editor binary refresh — permanent fix for the same pain)

## Test plan

- [ ] On a clean checkout of `claude/eloquent-murdock`, follow the new README section and confirm the `.app` runs Play button without \`Unknown command\` errors
- [ ] Preview rendered markdown on GitHub (no broken code blocks, blockquote renders correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)