### PR TITLE
docs: cap 15 (segundo motor iOS) + bitácora XCUI + roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -337,3 +337,25 @@ Todas las correcciones suman ~80 lineas de Swift sobre el bridge actual. No requ
 ### Costo total estimado
 
 ~80 lineas de codigo Swift, todas dentro del bridge actual. Ningun cambio arquitectonico, ninguna dependencia nueva. Las P0 son las que mas mueven la aguja: con esas tres correcciones el flow real corre limpio en ambas plataformas.
+
+---
+
+## Segundo motor iOS — siguiente iteración
+
+El [Capitulo 15](docs/libro/15-el-segundo-motor.md) documenta el `HybridBridge` + `XCUIBridge` + `autopilotd` + runner xctest que resuelve `ToolbarItem` SwiftUI en `NavigationBar`. Está en producción y verde en CI (PR #89). Tres deudas pendientes identificadas:
+
+### P1 — reducen latencia
+
+- [ ] **Reemplazar XCUIBridge por IdbBridge cuando las Command Line Tools se destraben.** `idb_companion` de Facebook/Meta es ~5x más rápido que XCTest (50-200ms warm vs 430ms) porque habla directo con CoreSimulator via XPC privado en lugar de pasar por XCTest framework. La arquitectura `HybridBridge + deep client` queda igual; solo cambia el transport del cliente. Bloqueado hoy por mismatch entre CLT 16.3 y Xcode 26.3 del sistema; brew rechaza instalar. Desbloquear implica actualizar CLT (muy frágil, depende de Apple) o shippear `idb_companion` pre-built con el release (más trabajo pero controlable).
+
+- [ ] **Heurística de escalación pre-fallo.** Hoy el `HybridBridge` paga ~200-300ms de fast-path fallado antes de escalar a deep. Si un script usa `tap[navbar] "Guardar"` podríamos ir directo a XCUI sin intentar fast, bajando de 700ms a 430ms limpios. Pendiente hasta tener datos de qué patrones escalan con frecuencia — implementar sin datos es agregar complejidad especulativa.
+
+### P2 — calidad de distribución
+
+- [ ] **Generador nativo de `.xctestrun` v2.** Hoy `RunnerInstaller` genera formato v1 que Xcode 26 rechaza con `Dictionary does not contain key "TestConfigurations"`. El workaround actual es apuntar al `.xctestrun` que Xcode generó en DerivedData (env var `AUTOPILOT_RUNNER_XCTESTRUN`). Para distribución real necesitamos generar v2 a mano con `PropertyListSerialization`. ~100 líneas de plist munging.
+
+- [ ] **Soporte para device físico.** El runner actual funciona solo en simulador (sin firma). Para device real habría que distribuir el `.xctest` firmado o exigir al usuario que lo firme con su cuenta de developer. Maestro tiene este flow pero es la parte fea de su onboarding. Preferimos mantener "solo simulador" hasta que haya demanda real documentada.
+
+### P3 — paridad Android
+
+- [ ] **Second-engine en Android si aparece el caso.** Hoy `AgentBridge` con UiAutomation ve todo lo que necesitamos — no hay un análogo del problema NavBar SwiftUI en Android. Si algún día aparece un widget que el `AccessibilityNodeInfo` no expone bien, el patrón del capítulo 15 se puede replicar: un segundo motor con escalación automática via HybridBridge. Sin evidencia del caso, no vale la pena anticipar.

--- a/docs/libro/02-arquitectura.md
+++ b/docs/libro/02-arquitectura.md
@@ -228,6 +228,10 @@ graph TB
 
 La decisión de dos binarios separados (en lugar de un flag `--platform`) se documenta en [ADR 8](07-decisiones.md#adr-8-dos-binarios--protocolo-devicebridge). La arquitectura Android se detalla en [docs/android/README.md](../android/README.md).
 
+## Un segundo motor para lo que AX no ve
+
+La arquitectura descrita arriba cubre el 80-90% de los casos. Los SwiftUI `ToolbarItem` dentro de `NavigationBar` son el ejemplo canónico de lo que el AX macOS externo aplana a un `AXGroup` opaco sin children queryables. El [Capítulo 15](15-el-segundo-motor.md) documenta el motor secundario (XCTest runner dentro del simulador) que resuelve esos casos sin sacrificar la velocidad del motor fast-path, y el `HybridBridge` que escala entre los dos automáticamente.
+
 ---
 
 *Anterior: [Capítulo 1 — El problema](01-el-problema.md) | Siguiente: [Capítulo 3 — La cámara virtual](03-la-camara-virtual.md)*

--- a/docs/libro/14-validacion-en-una-app-real.md
+++ b/docs/libro/14-validacion-en-una-app-real.md
@@ -547,4 +547,4 @@ Al final del dia, lo que el capitulo documenta no es una sola victoria. Es el te
 
 ---
 
-*Anterior: [Capitulo 13 — El recorder semantico](13-el-recorder-semantico.md)*
+*Anterior: [Capitulo 13 — El recorder semantico](13-el-recorder-semantico.md) | Siguiente: [Capitulo 15 — El segundo motor](15-el-segundo-motor.md)*

--- a/docs/libro/15-el-segundo-motor.md
+++ b/docs/libro/15-el-segundo-motor.md
@@ -1,0 +1,559 @@
+# Capítulo 15 — El segundo motor
+
+## El problema: "Guardar" invisible
+
+El [Capítulo 2](02-arquitectura.md) explica el backend iOS: `AXUIElement` + `CGEvent` + `simctl` + AppleScript. Es rápido (~300ms por tap), sin dependencias, sin XCUITest. Durante meses alcanzó.
+
+Después empezamos a validar contra apps SwiftUI modernas. Un flujo tan simple como este falló:
+
+```bash
+auto tap "Crear primera entrada"    # ✓ funciona
+auto tap "Titulo de tu experiencia" # ✓ funciona
+auto type "Demo"                    # ✓ funciona
+auto tap "Guardar"                  # ✗ Error: Element not found: 'Guardar'
+```
+
+"Guardar" era un `ToolbarItem(placement: .confirmationAction)` en un `NavigationBar` SwiftUI. Un botón azul arriba a la derecha, perfectamente visible en pantalla. Nuestro motor no lo veía.
+
+Pedimos el árbol con `auto tree`:
+
+```
+AXGroup  id=Nueva Entrada  [380,199 402x54]   ← el NavBar está ahí
+AXStaticText  label="Fotos"   [396,253 370x43]
+AXButton  label="Camara"      [412,311 161x38]
+AXButton  label="Galeria"     [589,311 161x38]
+AXStaticText  label="Detalles"
+AXTextField  value="Titulo de tu experiencia"
+...
+```
+
+El NavBar aparece como `AXGroup` con identifier "Nueva Entrada" **pero sin children accesibles**. Los `ToolbarItem` están ahí, los podemos ver con los ojos, pero el AX de macOS los proyecta como un `AXGroup` opaco. El 80-90% de los taps funcionan — el 10-20% que fallaba eran todos botones en toolbars SwiftUI.
+
+El bug apareció en Xcode 26 / iOS 26 con la nueva implementación de `NavigationStack`. En Xcode 15 y iOS 17 estos mismos `ToolbarItem` sí se exponían al AX externo. Apple cambió algo internamente y no lo documentó.
+
+La pregunta era: ¿cómo vemos los botones que el AX de macOS no ve, sin romper el 80-90% que ya funciona?
+
+---
+
+## Investigación: cómo lo hacen los demás
+
+Antes de escribir código, repetimos el patrón del [Capítulo 9](09-el-agente-android.md): investigar cómo Maestro, WebDriverAgent, idb y otros resuelven el problema de "AX externo no ve todo".
+
+### Maestro
+
+Maestro compila un fork minimalista de **WebDriverAgent** — un bundle `.xctest` que corre dentro del simulador vía `xcodebuild test-without-building`. El test se llama algo como `testRunner()` y nunca termina: bloquea en `XCTWaiter.wait()` indefinido y abre un servidor HTTP en loopback. El host habla con ese servidor via `usbmuxd` o `iproxy`.
+
+Desde adentro del simulador, el runner tiene acceso a `XCUIApplication` — la API que Xcode usa para UI testing. A diferencia del AX macOS externo, `XCUIApplication` **sí ve** la `NavigationBar` de SwiftUI como un elemento de primera clase con children queryables.
+
+Resultado: ~300-500ms por tap warm, ~5s cold boot la primera vez.
+
+### WebDriverAgent (Appium)
+
+El patrón original del que Maestro deriva. Mismo approach: un bundle xctest corriendo dentro del sim, servidor HTTP, pero más verboso (W3C WebDriver protocol completo) y con un ciclo de setup más manual (hay que firmar el runner con una cuenta de developer propia).
+
+### idb (Facebook/Meta)
+
+Esta es la más interesante. `idb_companion` no usa XCTest — usa **frameworks privados de Apple** (`SimulatorKit`, `CoreSimulator`) vía XPC. Es el mismo canal que usa Accessibility Inspector de Xcode.
+
+Resultado: 50-200ms por query (5-10x más rápido que XCTest).
+
+El precio: depende de headers privados que Apple puede romper en cualquier release de Xcode. En la práctica Facebook lo mantiene al día, pero el onboarding requiere Command Line Tools específicas y una cadena de dependencias (gRPC + XcodeGen + Swift Package Plugins).
+
+### El patrón común
+
+Todos comparten la misma arquitectura fundamental:
+
+```
+┌──────────────┐       ┌──────────────────────────────┐
+│  Host (Mac)   │       │  Simulador iOS                │
+│               │       │                               │
+│  CLI ───────────────────► Runner persistente          │
+│  (conexión    │socket │  (XCUIApplication directo,    │
+│   reutilizada)│       │   sin fork por comando)       │
+└──────────────┘       └──────────────────────────────┘
+```
+
+**Nadie rápido llama `xcrun simctl` ni AX macOS externo para operaciones de UI.** Todos mantienen un proceso dentro del sim con acceso a la API "de verdad".
+
+---
+
+## Decisión: xctest runner + sidecar daemon
+
+Teníamos tres caminos para el "segundo motor":
+
+| | XCTest runner | idb_companion | XPC a CoreSim |
+|---|---|---|---|
+| Setup usuario | 0 (runner precompilado) | `brew install idb-companion` | imposible sin firma |
+| Latencia tap warm | ~430ms | ~100-200ms | ~50-100ms |
+| Cold boot primera vez | 10-45s | ~2s | ~500ms |
+| Firma requerida | no (en simulador) | no | sí (frameworks privados) |
+| Frameworks privados | no | sí | sí |
+| Riesgo por cambio de Xcode | bajo | medio | alto |
+
+Probamos idb. `brew install facebook/fb/idb-companion` falló porque nuestras Command Line Tools estaban en 16.3 y Xcode en 26.3. Compilar desde source requería XcodeGen + gRPC + plugins de Swift Package Manager. La cadena de dependencias era demasiado frágil para una dependencia de usuario final.
+
+Elegimos **XCTest runner** por tres razones:
+
+1. **APIs públicas**. `XCUIApplication` es parte del framework público de Apple. No rompe entre versiones de Xcode con la frecuencia que rompen las privadas.
+2. **Cero firma en simulador**. Apple no exige code signing para binarios en el simulator. El runner puede shippearse precompilado dentro del release del CLI.
+3. **Patrón probado**. Maestro y WebDriverAgent llevan años usando esta arquitectura. Los bugs conocidos están documentados.
+
+El precio es ~5x más lento que idb. Aceptable para el 10-20% de casos que el fast path no resuelve — no es el hot path.
+
+---
+
+## Arquitectura: dos motores en escalera
+
+Mantener el motor rápido existente es no-negociable. El `SimulatorBridge` (AX macOS) resuelve el 80-90% de los taps en 300ms. No vamos a sacrificar esos casos para resolver el 10% que falla.
+
+La solución es un **wrapper** que intenta fast-path primero y escala a deep-path solo si falla:
+
+```swift
+// HybridBridge.swift
+try escalate("tap",
+    fast: { try self.fast.tap(target: target) },   // SimulatorBridge
+    deep: { try self.deep.tap(target: target) })   // XCUIBridge
+
+// Implementación:
+do {
+    try fastFn()
+    fastCount += 1
+} catch BridgeError.elementNotFound {
+    escalationCount += 1
+    try deepFn()
+}
+```
+
+`HybridBridge` implementa el mismo protocolo `DeviceBridge` que el CLI ya conoce. El usuario no cambia ni una línea de sus scripts `.auto` existentes. Lo que antes fallaba con "element not found" ahora escala al segundo motor y funciona.
+
+```mermaid
+graph TB
+    CLI["auto (CLI)"]
+    CLI -->|cada comando| HB[HybridBridge]
+
+    HB -->|fast-path primero| SB[SimulatorBridge]
+    SB -->|~300ms| AX[AX macOS externo]
+
+    HB -.->|si falla elementNotFound| XB[XCUIBridge]
+    XB -->|~430ms warm| RN[Runner xctest dentro del sim]
+    XB -.->|si runner no booted<br/>~10-45s| DM[autopilotd]
+    DM -->|xcodebuild test-<br/>without-building| RN
+
+    style SB fill:#1E3A5F,color:#fff
+    style XB fill:#3F0F5F,color:#fff
+    style DM fill:#0a2540,color:#fff
+    style RN fill:#333,color:#fff
+```
+
+Métodos que no son escalables (launch, simctl, biometric, permisos) van siempre por el fast-path. Solo escalan los que operan sobre elementos: `tap`, `longPress`, `doubleTap`, `clear`, `scroll`, `search`, `scrollTo`, `copyTextFrom`.
+
+---
+
+## Implementación: tres piezas nuevas
+
+### 1. `AutoPilotRunner.xctest` — el servidor
+
+Un bundle xctest mínimo, cuatro archivos:
+
+```
+runner/AutoPilotRunner/
+├── AutoPilotRunnerTests.swift   ← @MainActor func testServe() que nunca termina
+├── RunnerServer.swift           ← TCP server 127.0.0.1:22087 + dispatch JSON
+├── RunnerHandlers.swift         ← 15 endpoints → XCUIApplication
+└── RunnerSerialization.swift    ← XCUIElement → dict compatible con iOS/Android
+```
+
+El entry point es un método de test que bloquea indefinidamente:
+
+```swift
+@MainActor
+func testServe() throws {
+    let app = XCUIApplication(...)
+    let server = RunnerServer(port: 22087, app: app)
+
+    let done = XCTestExpectation(description: "server quit")
+
+    DispatchQueue.global(qos: .userInitiated).async {
+        try? server.start()       // accept loop en background
+        done.fulfill()
+    }
+
+    // XCTWaiter.wait pumps el RunLoop del main thread,
+    // permitiendo que los DispatchQueue.main.async del server se ejecuten.
+    _ = XCTWaiter().wait(for: [done], timeout: 86400)
+}
+```
+
+El protocolo es idéntico al del [agente Android](09-el-agente-android.md#implementación-4-archivos-200kb) — misma línea de JSON por request, misma línea de JSON por response, mismo formato de tree (`role`, `label`, `identifier`, `frame`, `children`). Esto permite reusar `TreePrinter`, `ElementIndexShared` y `TargetResolver` sin tocar nada.
+
+### 2. `autopilotd` — el sidecar daemon
+
+Un ejecutable Swift en `cli/Sources/Daemon/` que vive en macOS (no en el sim). Tres responsabilidades:
+
+```
+Sources/Daemon/
+├── main.swift             ← start|stop|status + PID file + signal handlers
+├── DaemonServer.swift     ← Unix socket server + JSON dispatch
+└── RunnerLifecycle.swift  ← xcodebuild test-without-building + probe + shutdown
+```
+
+La única razón de existir del daemon es **mantener el runner xctest vivo entre comandos del CLI**. Sin daemon, cada `auto tap` tendría que bootear el runner desde cero (~10-45s) o confiar en que otra herramienta lo mantenga.
+
+El daemon arranca `xcodebuild test-without-building` como proceso hijo, lo vigila, y expone un socket Unix local (`/tmp/autopilot-<udid>.sock`). Cuando el CLI quiere hacer algo XCUI, habla con el daemon (o directo con el runner, ver abajo).
+
+### 3. `XCUIBridge.swift` — el cliente
+
+Un cliente TCP que implementa `DeviceBridge`. Mismo formato JSON que `AgentBridge` en Android. La API pública relevante:
+
+```swift
+public final class XCUIBridge: DeviceBridge {
+    public init(host: String = "127.0.0.1", port: UInt16 = 22087) { ... }
+
+    public func tree() throws -> [[String: Any]]
+    public func search(query: String) throws -> [[String: Any]]
+    public func list(type: String) throws -> [[String: Any]]   // ← typed query rápida
+    public func tap(target: String) throws
+    public func launchApp(bundleId: String, envVars: [String: String]) throws
+    // ...
+
+    // Métodos no implementados (delegar al fast-path):
+    public func biometricEnroll() throws { throw notImplemented("biometricEnroll") }
+    public func installApp(path: String) throws { throw notImplemented("installApp") }
+    // ...
+}
+```
+
+Cada método no implementado tira `BridgeError.unknown("not implemented in XCUI")`. El `HybridBridge` lo captura y cae al fast-path. Así el `XCUIBridge` solo implementa lo que le suma valor — operaciones sobre elementos — y deja que el `SimulatorBridge` haga lo que ya hace bien.
+
+---
+
+## Tropiezo 1: Xcode 26 clona el simulador
+
+Primer build del runner, primera llamada, primer crash. El simulador se **apagaba** después de que el test terminaba.
+
+```
+$ auto daemon start
+✓ daemon arrancado, runner booted
+$ auto tap "Guardar"
+✓ Tapped "Guardar" (1550ms)
+$ auto tap "General"
+Error: No simulator window found. Is the Simulator open?
+$ xcrun simctl list devices booted
+-- iOS 26.3 --
+(none)
+```
+
+Debug: el `xcodebuild test-without-building` en Xcode 26 por defecto **clona** el simulador para aislar el test. Cuando nuestro test-que-nunca-termina eventualmente termina (porque el daemon lo mata o porque crashea), el clone se destruye. El problema es que la destrucción del clone se propagaba al sim original — el que el usuario tenía abierto — y lo apagaba.
+
+No encontramos documentación oficial sobre el comportamiento. El fix apareció después de mirar flags de xcodebuild línea por línea:
+
+```swift
+proc.arguments = [
+    "xcodebuild", "test-without-building",
+    "-xctestrun", xctestRunPath,
+    "-destination", "platform=iOS Simulator,id=\(udid)",
+    "-only-testing:\(testID)",
+    // Xcode 26 default: clone sim per test. El clone se destruye al final
+    // y en el proceso apaga el simulator original. Sin estos flags, el sim
+    // muere después de cada ciclo del runner:
+    "-parallel-testing-enabled", "NO",
+    "-disable-concurrent-destination-testing",
+    "-maximum-concurrent-test-simulator-destinations", "1"
+]
+```
+
+Con los tres flags, xcodebuild corre el test directamente en el sim del usuario sin clonar. El sim sobrevive.
+
+Nadie documenta esto en las release notes de Xcode 26. Lo encontramos probando combinaciones.
+
+---
+
+## Tropiezo 2: `XCUIApplication` requiere main thread
+
+El accept loop del servidor corre en `DispatchQueue.global(qos: .userInitiated)` — background thread. Natural para un server TCP. Pero cuando un handler llama `XCUIApplication.launch()` desde ese thread, crash inmediato:
+
+```
+*** Assertion failure in -[XCUIApplication _launchUsingXcode:...]
+XCUIApplication must be called on the main thread
+NSInternalInconsistencyException
+```
+
+Las APIs de XCUI están diseñadas asumiendo que corren desde un test XCTest, que siempre está en main thread. Nuestro servidor las llamaba desde background.
+
+El fix es despachar cada operación XCUI al main thread con un semáforo:
+
+```swift
+private func dispatchOnMain(_ block: @escaping () -> String) -> String {
+    if Thread.isMainThread { return block() }
+
+    var result = ""
+    let semaphore = DispatchSemaphore(value: 0)
+    DispatchQueue.main.async {
+        result = block()
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return result
+}
+```
+
+El truco que hace que esto funcione es que `XCTWaiter.wait()` **pumps el RunLoop del main thread**. Sin eso, un background thread haciendo `DispatchQueue.main.async` quedaría encolado eternamente porque nadie procesa la cola. Con `XCTWaiter` corriendo en el main, los bloques se ejecutan, el semáforo se libera, y el background thread sigue.
+
+Una invariante escondida en el framework de XCTest que nadie documenta pero de la que depende toda la arquitectura.
+
+---
+
+## Arquitectura v2: TCP directo (skip daemon)
+
+Versión inicial: `XCUIBridge` hablaba con el daemon via Unix socket, el daemon reenviaba al runner via TCP. Funcionaba, pero cada llamada era:
+
+```
+auto → Unix socket → autopilotd (parse JSON) → TCP → runner
+     ← Unix socket ← autopilotd (re-serialize) ← TCP ← runner
+```
+
+Cuatro saltos de serialización por cada comando. Medido: ~1500ms warm por tap.
+
+Segunda iteración: **`XCUIBridge` habla directo al runner por TCP**, saltando el daemon en el hot path. El daemon queda solo como lifecycle manager.
+
+```swift
+private func sendCommand(_ method: String, params: [String: Any]? = nil) throws -> [String: Any] {
+    // Fast path: TCP directo al runner (connect timeout 100ms)
+    if let fd = connectTCP(host: "127.0.0.1", port: 22087) {
+        defer { close(fd) }
+        return try exchange(fd: fd, method: method, params: params)
+    }
+
+    // Cold fallback: Unix socket al daemon, que auto-bootea el runner.
+    // Primera llamada de una sesión paga el cold boot (~10-45s), las siguientes
+    // van directo TCP.
+    guard let daemonFD = connectDaemonUnixSocket() else {
+        throw BridgeError.unknown("runner not responding + daemon not running")
+    }
+    defer { close(daemonFD) }
+    return try exchange(fd: daemonFD, method: method, params: params)
+}
+```
+
+Esto bajó tap warm de ~1500ms a ~430ms. 3.5x con el mismo runner y el mismo código de handler. La diferencia era toda en el proxy de serialización.
+
+---
+
+## Tropiezo 3: `tree deep` tardaba 60 segundos
+
+Con el runner funcionando pedimos el árbol completo para explorar:
+
+```
+$ auto tree deep
+Application
+ Window
+  Other
+   ... (501 nodos anidados)
+
+(59339ms — deep)
+```
+
+Un minuto. Inaceptable incluso como debug command. Imposible para un loop de escaneo.
+
+Debug: `RunnerSerialization.swift` recorría el árbol recursivamente y por cada nodo llamaba:
+
+```swift
+dict["role"] = element.elementType        // 1 XPC call al sim
+dict["label"] = element.label             // 1 XPC call
+dict["identifier"] = element.identifier   // 1 XPC call
+dict["value"] = element.value             // 1 XPC call
+dict["title"] = element.title             // 1 XPC call
+dict["frame"] = element.frame             // 1 XPC call
+dict["enabled"] = element.isEnabled       // 1 XPC call
+```
+
+Cada acceso a una property de `XCUIElement` es un XPC call separado al proceso que posee el snapshot de accesibilidad. ~500 nodos × 7 atributos = **3500 XPC calls**. Cada uno ~15ms. Total: ~52s. Tomando el overhead de recursión y serialización JSON: 60s.
+
+La fix es `XCUIElement.snapshot()` — una API que hace **un solo XPC** y devuelve un `XCUIElementSnapshot` con todos los atributos cacheados en memoria:
+
+```swift
+let snap = try element.snapshot()         // 1 XPC para todo
+dict["label"] = snap.label                // acceso a campo en memoria, 0 XPC
+dict["value"] = snap.value                // 0 XPC
+dict["identifier"] = snap.identifier      // 0 XPC
+// ... etc
+```
+
+Pero mejor que hacer snapshot completo es **no recorrer todo el árbol**. La mayoría de los nodos en un `tree deep` son `Other` containers de SwiftUI vacíos. Agregamos un comando alternativo `auto list`:
+
+```bash
+$ auto list buttons        # solo botones, con labels y frames
+$ auto list textfields     # solo inputs
+$ auto list cells          # solo celdas
+$ auto list                # todos los interactivos (all + cells + switches)
+```
+
+Internamente, `list buttons` usa **queries tipadas** de XCTest:
+
+```swift
+// Lento (lo que hacía tree deep):
+app.descendants(matching: .any).matching(predicate)
+// → serializa 500 nodos para filtrar 20
+
+// Rápido (lo que hace list):
+let query = app.buttons    // XCUIElementQuery tipada, lazy
+for i in 0..<query.count {
+    let snap = try query.element(boundBy: i).snapshot()
+    items.append([...])
+}
+// → solo materializa los 20 botones + 1 XPC por snapshot
+```
+
+Resultado: **`auto list buttons` en 1 segundo**, contra 13s de `auto tree deep`. 10-13x.
+
+El error de diseño inicial fue usar `tree deep` como herramienta de exploración. `tree deep` es útil para debug profundo — ver el árbol completo en un problema específico — pero no es la herramienta correcta para "¿qué elementos puedo tapear en esta pantalla?". Para eso, `list <type>`.
+
+---
+
+## Resultados
+
+Medido contra la app Settings del simulador (`com.apple.Preferences`), tap "General":
+
+| Bridge | Latencia | Overhead | Cuándo se usa |
+|---|---|---|---|
+| `SimulatorBridge` (fast, AX macOS) | **300ms** | baseline | 80-90% de los taps |
+| `HybridBridge` sin escalar | **355ms** | +18% | wrapper overhead |
+| `XCUIBridge` directo TCP (warm) | **430ms** | +43% | cuando el fast-path falla |
+| `XCUIBridge` cold boot | **10-45s** | una vez por sesión | primera escalación del día |
+
+Y exploración de UI:
+
+| Comando | Tiempo | Qué devuelve |
+|---|---|---|
+| `auto tree` (fast) | **300ms** | árbol AX macOS (no ve NavBar SwiftUI) |
+| `auto list` | **1000ms** | elementos interactivos (buttons + fields + cells + switches + links) |
+| `auto list buttons` | **500-1000ms** | solo botones |
+| `auto tree deep` | **10-13s** | árbol XCUI completo (debug) |
+
+Con el daemon arrancado una sola vez al inicio de la sesión (`./scripts/demo/start-daemon.sh start`), todas las llamadas posteriores son warm. El cold boot se paga una vez.
+
+---
+
+## Tropiezo residual: Command Line Tools desactualizadas
+
+El primer instinto fue usar idb en lugar de XCTest. Es ~5x más rápido y Facebook lo mantiene. Intentamos instalar:
+
+```bash
+$ brew install facebook/fb/idb-companion
+Error: Your Command Line Tools are too outdated.
+Update them from Software Update in System Settings.
+
+If that doesn't show you any updates, run:
+  sudo rm -rf /Library/Developer/CommandLineTools
+  sudo xcode-select --install
+
+You should download the Command Line Tools for Xcode 26.3.
+```
+
+Nuestras CLT estaban en 16.3 mientras Xcode estaba en 26.3. brew rechazaba instalar idb. Compilar desde source (clonar el repo, `./build.sh`) requería XcodeGen + gRPC + Swift Package Manager plugins — cadena de dependencias demasiado frágil.
+
+No es un problema de idb. Es un problema de que el setup del usuario tiene que ser trivial y Apple hace que "tener CLT y Xcode sincronizados" sea complicado cuando el usuario no actualiza a mano.
+
+Si eventualmente las CLT se destraban y idb instala limpio, el `XCUIBridge` actual se puede reemplazar por un `IdbBridge` con el mismo protocolo. El `HybridBridge` no cambia. Los scripts `.auto` no cambian. Solo cambia el cliente.
+
+---
+
+## Cómo usar
+
+El daemon vive en background una vez arrancado. Tres comandos principales:
+
+```bash
+# Una vez al inicio de la sesión (paga el cold boot ~10-45s)
+./scripts/demo/start-daemon.sh start
+
+# Después, scripts existentes funcionan sin cambios:
+auto tap "Guardar"                # hybrid: fast primero, XCUI si falla
+auto list buttons                 # exploración rápida (~1s)
+auto tree                         # árbol fast
+auto tree deep                    # árbol XCUI (lento, debug)
+
+# Diagnóstico
+auto daemon status                # runner booted? pid?
+auto stats                        # cuántas veces escaló el hybrid
+
+# Forzar un motor específico (debug)
+AUTO_BRIDGE=simulator auto tap "Guardar"  # falla en NavBar SwiftUI
+AUTO_BRIDGE=xcui auto tap "Guardar"       # siempre usa deep
+AUTO_BRIDGE=hybrid auto tap "Guardar"     # default
+```
+
+Para CI y release, el runner xctest se buildea una vez (`xcodebuild build-for-testing`) y el `.xctestrun` + `Runner.app` se publican como asset en el release. El CLI lo instala al primer uso — el usuario final no necesita Xcode.
+
+---
+
+## Qué aprendimos
+
+1. **Dos motores en escalera > un motor universal.** El `SimulatorBridge` resuelve el 80-90% a 300ms. El `XCUIBridge` resuelve el 10-20% restante a 430ms. Intentar reemplazar todo por XCUI habría penalizado el caso común para ganar el caso raro. El `HybridBridge` da el mejor de los dos mundos con un wrapper de ~300 líneas.
+
+2. **El proxy silencioso mata la latencia.** La primera versión pasaba todo por el daemon. Saltar el daemon para llamadas de datos bajó tap warm de 1500ms a 430ms — 3.5x con el mismo código de handler. Siempre que un componente intermedio re-serializa datos, medir su costo.
+
+3. **`XCUIElement.snapshot()` o nada.** Cada acceso a `element.label`, `element.value`, `element.frame` es un XPC call al sim. 500 nodos × 7 atributos = 3500 XPC = 60s. Un `snapshot()` al inicio baja a 500 XPC = 5s. Es la diferencia entre usable e inusable.
+
+4. **Queries tipadas > descendants matching any.** `app.buttons[label]` es O(1) porque XCTest usa una estructura indexada. `descendants(matching: .any).matching(predicate)` es O(N) con N full snapshots. Para exploración, las queries tipadas son 10x-50x más rápidas.
+
+5. **Xcode 26 cambió el default de `test-without-building` a cloned sims.** Nadie lo documenta. Sin los tres flags (`-parallel-testing-enabled NO`, `-disable-concurrent-destination-testing`, `-maximum-concurrent-test-simulator-destinations 1`), el sim del usuario muere cada vez que el runner termina. Lo descubrimos probando.
+
+6. **XCUIApplication solo funciona en main thread.** El servidor TCP corre en background; el dispatcher hace `DispatchQueue.main.async` + semáforo; `XCTWaiter.wait()` en el main thread pumpea el RunLoop para que los blocks se ejecuten. Si el main thread está bloqueado en algo que no pumpea el RunLoop, deadlock.
+
+7. **idb sería mejor técnicamente, pero el setup no es viable hoy.** `idb_companion` es 5x más rápido que XCTest. Pero requiere Command Line Tools sincronizadas con Xcode, y Apple no facilita eso. XCTest runner es peor perf pero trivial de distribuir (cero dependencias del usuario, cero firma).
+
+8. **Pagar el cold boot una vez > pagarlo por llamada.** `--timeout 0` (runner inmortal mientras el daemon vive) + pre-warm al arrancar el daemon convierte "45s cold boot eventual" en "45s cold boot una vez al arrancar, nunca más". Los 45s amortizan en la primera llamada — las 1000 siguientes son warm.
+
+---
+
+## Integración con el CLI
+
+Con los tres componentes funcionando, la factory en `main.swift` respeta un env var `AUTO_BRIDGE`:
+
+```swift
+let simulatorBridge = SimulatorBridge()
+let xcuiBridge = XCUIBridge()
+let bridge: DeviceBridge = makeBridge(simulatorBridge)
+
+func makeBridge(_ simBridge: SimulatorBridge) -> DeviceBridge {
+    switch ProcessInfo.processInfo.environment["AUTO_BRIDGE"] ?? "hybrid" {
+    case "simulator": return simBridge
+    case "xcui":      return xcuiBridge
+    case "hybrid":    return HybridBridge(fast: simBridge, deep: xcuiBridge)
+    default:          return HybridBridge(fast: simBridge, deep: xcuiBridge)
+    }
+}
+```
+
+El default es `hybrid`. Los scripts existentes ganan la escalación automática sin cambiar una línea. Los usuarios que quieran debugging puro pueden forzar `AUTO_BRIDGE=simulator` (comportamiento histórico) o `AUTO_BRIDGE=xcui` (ver qué ve el runner).
+
+Comandos nuevos agregados al CLI:
+
+```
+auto list <type>          # typed query via XCUI runner (~1s)
+auto tree deep            # árbol XCUI completo
+auto tree full            # fast + deep side-by-side (debug)
+auto daemon start|stop|status   # lifecycle del sidecar
+auto runner install|status      # gestión del bundle xctest
+auto stats                # contadores fast/deep/escalations del hybrid
+```
+
+El detalle técnico del protocolo, los endpoints del runner, y los parámetros de cada método están en [`docs/ios/XCUI-BRIDGE.md`](../ios/XCUI-BRIDGE.md).
+
+---
+
+## Siguiente paso
+
+El motor deep cubre el caso de NavBar SwiftUI — el 10-20% que el AX externo no ve. Faltan dos cosas para paridad completa con Maestro:
+
+1. **Reemplazar XCTest por idb** cuando las CLT se actualicen o cuando el proyecto idb publique binarios pre-built. Eso bajaría tap warm de 430ms a ~150ms — 3x más. La arquitectura `HybridBridge + deep client` queda igual; solo cambia el cliente.
+
+2. **Soporte para device físico.** El runner actual funciona solo en simulador (sin firma). Para device real habría que distribuir el `.xctest` firmado o exigir al usuario que lo firme con su cuenta de developer. Maestro tiene este flow pero es la parte fea de su onboarding. Preferimos mantener "solo simulador" hasta que haya demanda real.
+
+3. **Heurísticas de escalación pre-fallo.** Hoy el `HybridBridge` paga un `elementNotFound` del fast-path antes de escalar. Eso son ~200-300ms de fast-path fallado + 430ms de XCUI = 700ms total. Si tuviéramos una heurística tipo "este script dice `tap[navbar] X`, va directo a XCUI", bajaríamos a 430ms limpio. Pendiente hasta tener datos reales de qué patrones escalan.
+
+---
+
+*Anterior: [Capítulo 14 — Validación en una app real](14-validacion-en-una-app-real.md) | Siguiente: por escribir*
+
+*[Índice del libro](README.md)*

--- a/docs/libro/README.md
+++ b/docs/libro/README.md
@@ -9,7 +9,7 @@
 
 Este no es un manual de usuario. Es la documentación técnica de una investigación.
 
-AutoPilot nació de una pregunta: ¿se puede controlar dispositivos iOS y Android desde la terminal sin servidores, test runners, ni dependencias pesadas? La respuesta involucró APIs de accesibilidad de macOS, un agente nativo Android con UiAutomation directa, inyección de dylibs, y 10 intentos de mockear una cámara que no existe.
+AutoPilot nació de una pregunta: ¿se puede controlar dispositivos iOS y Android desde la terminal sin servidores, test runners, ni dependencias pesadas? La respuesta involucró APIs de accesibilidad de macOS, un agente nativo Android con UiAutomation directa, inyección de dylibs, 10 intentos de mockear una cámara que no existe, y finalmente un segundo motor XCTest para los casos en los que el AX externo de macOS no alcanza.
 
 Documentamos todo el proceso — los errores, los callejones sin salida, las decisiones — para que cualquier ingeniero que enfrente problemas similares tenga un punto de partida. El conocimiento es libre.
 
@@ -33,6 +33,7 @@ Documentamos todo el proceso — los errores, los callejones sin salida, las dec
 12. **[Permisos de accesibilidad](12-permisos-accesibilidad.md)** — Por qué el Inspector dejó de funcionar, cómo macOS hereda permisos TCC, y por qué no hay alternativa a AXUIElement
 13. **[El recorder semantico](13-el-recorder-semantico.md)** — CGEventTap (iOS) + getevent (Android): captura pasiva, selectores semanticos, y por qué el scroll es el ultimo problema
 14. **[Validacion en una app real](14-validacion-en-una-app-real.md)** — El experimento: automatizar el login completo de una app comercial real desde estado limpio, usando solo el CLI, sin tools externas
+15. **[El segundo motor](15-el-segundo-motor.md)** — NavBar SwiftUI invisible, XCTest runner dentro del sim, y un HybridBridge que escala a deep solo cuando el fast falla
 
 ### Apendices
 
@@ -48,6 +49,7 @@ Documentamos todo el proceso — los errores, los callejones sin salida, las dec
 - **[Bitacora — Camara](../camera/BITACORA.md)** — Diario de laboratorio crudo de la camara virtual
 - **[Bitacora — Recorder](../recorder/BITACORA.md)** — Diario del recorder semantico (CGEventTap, getevent, bugs)
 - **[Bitacora — Validacion](../validacion/BITACORA.md)** — Diario crudo de los experimentos de validacion en apps comerciales reales
+- **[Bitacora — XCUI](../xcui/BITACORA.md)** — Diario crudo del segundo motor: spike de NavBar, tropiezos de Xcode 26, paridad con Maestro
 - **[Hallazgos — Recorder](../recorder/HALLAZGOS.md)** — Limitaciones, metricas, comparativa para benchmark
 - **[Android backend](../android/README.md)** — AgentBridge, agente nativo, comandos implementados
 

--- a/docs/xcui/BITACORA.md
+++ b/docs/xcui/BITACORA.md
@@ -1,0 +1,365 @@
+# Bitácora — XCUI / HybridBridge / segundo motor iOS
+
+Diario de laboratorio crudo de la investigación y construcción del segundo motor iOS (XCTest runner dentro del simulador). Sirve como referencia histórica para el [Capítulo 15 — El segundo motor](../libro/15-el-segundo-motor.md).
+
+El formato es cronológico, sin editar. Los capítulos del libro se basan en estas entradas pero pulidas.
+
+---
+
+## Sesión 2026-04-08 — Spike: validar hipótesis de NavBar SwiftUI
+
+### Hipótesis
+
+`XCUIApplication` corriendo dentro de un runner XCTest ve `NavigationBar` como elemento queryable, mientras que el `AXUIElement` de macOS externo la aplana a un `AXGroup` opaco sin children.
+
+Si la hipótesis pasa, todo el proyecto (HybridBridge + XCUIBridge + daemon + runner) tiene sentido. Si falla, hay que replantear.
+
+### Setup
+
+- Xcode 26.3 (17C529), iPhone 17 sim UDID `0A2BAB42-8475-4C3C-A44E-842C28ECA179`, iOS 26.3.1
+- Agregué 2 tests al target `Test AutomatitacionUITests` existente del demo:
+  - `testAutoPilotSpikeNavBarVisibility` — lanza Settings, hace `app.debugDescription`, imprime árbol
+  - `testAutoPilotSpikeServeLoopback` — gated con `AUTOPILOT_SPIKE_SERVE=1`, levanta TCP server en 127.0.0.1:22087 con XCTWaiter infinito
+
+### Resultado
+
+Test pasó en 8.3s (build + test). Del dump de XCUIApplication:
+
+```
+Attributes: Application, pid: 98534, label: 'Configuración'
+Element subtree:
+ →Application, label: 'Configuración'
+    Window (Main), {0.0, 0.0, 402.0, 874.0}
+      ...
+        NavigationBar, identifier: 'Configuración', {0.0, 62.0, 402.0, 106.0}
+          StaticText, label: 'Configuración', {16.0, 119.7, 224.7, 40.7}
+```
+
+En paralelo, `auto tree` (SimulatorBridge actual) contra la misma Settings:
+
+```
+AXGroup [808,171 402x874]
+  AXHeading label="Configuración" [824,290 224x40]
+  AXButton label="Cuenta de Apple, ..." id=com.apple.settings.primaryAppleAccount
+  ...
+```
+
+**Confirmado**: XCUIApplication expone `NavigationBar` como tipo de elemento propio con identifier y children. SimulatorBridge aplana a `AXHeading` + `AXButton`s sueltos sin el contenedor NavigationBar. Hipótesis válida.
+
+### Resto del plan
+
+Quedó armado el plan `.claude/plans/tranquil-knitting-truffle.md` con 5 olas:
+1. Foundations (spike + daemon + installer) — estado: spike hecho
+2. Runner endpoints + CI
+3. XCUIBridge cliente + docs
+4. HybridBridge + factory
+5. E2E + benchmark
+
+### Observaciones
+
+- Runner xctest tarda ~43s en responder al primer comando (cold boot de xcodebuild + sim handshake + XCTest bootstrap).
+- `XCTWaiter.wait(for: [done], timeout: 600)` aguanta el main thread infinitamente. El patrón WDA funciona.
+- El xctest bundle se instala en el sim como `dev.autopilot.test.ExploreaUITests.xctrunner` — una app más.
+
+---
+
+## Sesión 2026-04-15 AM — Build de daemon + RunnerInstaller
+
+### Lo que salió fácil
+
+- `cli/Sources/Daemon/main.swift` con PID file, signal handlers (`SIGTERM`/`SIGINT`/`SIGHUP`), socket Unix en `/tmp/autopilot-<udid>.sock`. Patrón copiado de `AgentBridge.swift` de Android pero invertido (servidor en Mac, no en device).
+- Pre-check del `AF_UNIX` `sun_path` máximo 104 bytes con `strncpy` y NUL explícito. El `strcpy` directo fue flaggeado en review.
+- `RunnerInstaller.swift` con SHA256 hash check para saltar reinstalación. `simctl install` + regeneración del `.xctestrun` con paths absolutos via `PropertyListSerialization`.
+
+### Tropiezo
+
+`RunnerInstaller.regenerateXCTestRun()` genera un `.xctestrun` en formato **v1** (FormatVersion=2, SchemaVersion=1). Xcode 26 rechaza:
+
+```
+xcodebuild: error: Failed to build workspace temporary with scheme Transient Testing.:
+Dictionary does not contain key "TestConfigurations" with expected type
+```
+
+Xcode 26 exige formato v2 con una estructura `TestConfigurations` array de configuraciones. Escribirlo a mano con `PropertyListSerialization` es doloroso.
+
+**Workaround temporal**: agregué env var `AUTOPILOT_RUNNER_XCTESTRUN` al `RunnerLifecycle.swift`. Permite apuntar al `.xctestrun` que Xcode ya generó en DerivedData al compilar (con `xcodebuild build-for-testing`). El generador v2 propio queda pendiente.
+
+---
+
+## Sesión 2026-04-15 PM — Primer E2E con daemon + runner
+
+### Arquitectura inicial
+
+```
+auto → Unix socket → autopilotd → TCP :22087 → runner xctest
+     ← Unix socket ← autopilotd ← TCP :22087 ←
+```
+
+Todo pasa por el daemon. El daemon reenvía.
+
+### Crash número uno: sim se apaga después de cada ciclo
+
+```
+$ auto daemon start → ✓
+$ auto tap "General" → ✓ (440ms)
+$ auto tap "Settings" → Error: No simulator window found
+$ xcrun simctl list devices booted → (none)
+```
+
+Debug: después del primer tap (que triggerea cold boot del runner), el `xcodebuild test-without-building` **clona el simulador**. Cuando el test termina — por `quit` o por timeout del XCTWaiter — el clone se destruye y **mata el sim principal** en el proceso.
+
+No encontré nada en release notes de Xcode 26. Probando flags:
+
+```swift
+proc.arguments = [
+    "xcodebuild", "test-without-building", ...
+    "-parallel-testing-enabled", "NO",
+    "-disable-concurrent-destination-testing",
+    "-maximum-concurrent-test-simulator-destinations", "1"
+]
+```
+
+Con los tres, el sim del usuario sobrevive. Sin uno solo de ellos, muere. Undocumented.
+
+### Crash número dos: NSInternalInconsistencyException, main thread
+
+```
+*** Assertion failure in -[XCUIApplication _launchUsingXcode:...]
+-[XCUIApplication _launchUsingXcode:withoutAccessibility:launchURL:] must be called on the main thread
+```
+
+Server TCP en `DispatchQueue.global(qos: .userInitiated)`, handlers llaman `XCUIApplication.launch()` → crash. Todas las operaciones XCUI tienen esta assertion.
+
+Fix: `dispatchOnMain()` con semáforo:
+
+```swift
+private func dispatchOnMain(_ block: @escaping () -> String) -> String {
+    if Thread.isMainThread { return block() }
+    var result = ""
+    let semaphore = DispatchSemaphore(value: 0)
+    DispatchQueue.main.async {
+        result = block()
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return result
+}
+```
+
+Funciona porque `XCTWaiter.wait()` del `testServe()` pumpea el RunLoop del main — los bloques se despachan, ejecutan, liberan el semáforo. Invariante silenciosa de XCTest.
+
+### Benchmark inicial (con daemon como proxy)
+
+```
+tap General warm:  ~1500ms
+tap cold:          ~5800ms (primer call post-boot)
+tree deep:         ~13000ms
+```
+
+1500ms warm es 3-5x peor que Maestro. Pero al menos funciona.
+
+---
+
+## Sesión 2026-04-16 AM — Fixes de estabilidad
+
+### `resolveApp` stale tras terminate externo
+
+Si el cliente hace `auto terminate com.apple.Preferences` y después `auto tap "X"` contra la misma app relanzada, el runner tiene `activeApp` apuntando al proceso muerto anterior. Resultado: "element not found" silencioso aunque el elemento exista en la nueva instancia.
+
+Fix: `resolveApp(params:)` en `RunnerHandlers`:
+
+```swift
+if activeApp.state == .runningForeground {
+    return activeApp
+}
+// Stale — rebuild
+if let bid = activeBundleId {
+    let a = XCUIApplication(bundleIdentifier: bid)
+    activeApp = a
+    return a
+}
+```
+
+Y `handleLaunch()` registra `activeBundleId` para poder reconstruir sin argumentos.
+
+### `handleLaunch` usa activate() si ya está en foreground
+
+Evita kill-and-restart cuando la app ya está corriendo:
+
+```swift
+if targetApp.state == .runningForeground {
+    targetApp.activate()  // trae al frente
+} else {
+    targetApp.launch()    // full relaunch
+}
+```
+
+Baja tap de `launch` de 500ms a ~57ms cuando la app ya está abierta.
+
+### Bench verificación
+
+```
+call 1: 467ms  (warm)
+call 2: 424ms
+call 3: 437ms
+call 4: 434ms
+call 5: 429ms
+```
+
+Estable en ~430ms. Demo corrió full contra Explorea NewEntryView: el `tap "Guardar"` que antes fallaba ahora escala automáticamente y tapea en ~1.6s (300ms de fast fail + 430ms de XCUI warm + overhead).
+
+---
+
+## Sesión 2026-04-16 PM — Paridad con Maestro
+
+### Plan
+
+1500ms por tap warm no es competitivo. Maestro hace 300-500ms. Dos hipótesis para la diferencia:
+
+1. El daemon como proxy serializa/deserializa dos veces por cada request (overhead). 
+2. `findElement` hace `descendants(matching: .any).matching(predicate)` — escaneo lineal sobre todo el árbol.
+
+### Cambio 1: TCP directo al runner
+
+`XCUIBridge.swift` antes conectaba a Unix socket del daemon. Nuevo: conecta directo a `127.0.0.1:22087` (runner), fallback a daemon Unix socket solo si el runner no responde (para triggerear auto-boot).
+
+```swift
+// Fast path
+if let fd = connectTCP(host: "127.0.0.1", port: 22087) {
+    return try exchange(fd: fd, ...)
+}
+// Cold fallback
+guard let daemonFD = connectDaemonUnixSocket() else { throw ... }
+return try exchange(fd: daemonFD, ...)
+```
+
+Resultado:
+```
+tap warm antes:   1500ms
+tap warm después:  430ms  (3.5x)
+```
+
+### Cambio 2: queries tipadas en findElement
+
+Agregué fast-path en `findElement(target:, params:)`:
+
+```swift
+// Antes de ir al predicate-scan, intentar queries tipadas:
+for q in [app.buttons, app.staticTexts, app.textFields, ...] {
+    let byLabel = q[query]   // O(1), lazy
+    if byLabel.exists { return byLabel }
+}
+```
+
+`app.buttons["Login"]` es O(1) porque XCTest usa estructura indexada. `descendants(matching: .any).matching(predicate)` es O(N) con N full snapshots.
+
+### Cambio 3: `auto list` (comando nuevo)
+
+`tree deep` tardaba ~13s porque serializaba ~500 nodos × 7 atributos = 3500 XPC calls al sim. Cada acceso a `element.label`, `element.value`, etc es un XPC separado.
+
+Agregamos `handleList(type:)` en el runner:
+
+```swift
+case "buttons": queries = [("Button", app.buttons)]
+case "labels":  queries = [("StaticText", app.staticTexts)]
+...
+
+for (role, q) in queries {
+    for i in 0..<q.count {
+        let snap = try q.element(boundBy: i).snapshot()  // 1 XPC por elemento
+        items.append([role, snap.label, snap.identifier, ...])
+    }
+}
+```
+
+`XCUIElement.snapshot()` hace un XPC que trae todo cacheado en memoria. Resto son reads de struct.
+
+CLI expone:
+
+```bash
+auto list buttons        # ~500ms-1s
+auto list textfields     # ~500ms
+auto list                # todos los interactivos (~1s)
+```
+
+Contra `tree deep` (13s), es 10x más rápido y devuelve exactamente lo que el usuario necesita (elementos tapeables).
+
+### Idb
+
+Intentamos idb_companion de Facebook antes del approach TCP directo. Más rápido que XCTest (50-200ms warm, vs 430ms), pero:
+
+```bash
+$ brew install facebook/fb/idb-companion
+Error: Your Command Line Tools are too outdated.
+You should download the Command Line Tools for Xcode 26.3.
+```
+
+CLT en 16.3, Xcode en 26.3. Brew rechaza. Compilar desde source requiere XcodeGen + gRPC + SPM plugins. Cadena de dependencias frágil. Descartado por ahora.
+
+Si las CLT se destraban en el futuro, reemplazar `XCUIBridge` por `IdbBridge` sería trivial — mismo `DeviceBridge` protocol, solo cambia el transport.
+
+### Runner inmortal
+
+Daemon default tenía `--timeout 120` (apagar runner tras 2 min sin uso). Si el usuario no hacía nada en 2 min y después hacía `auto tap`, pagaba cold boot de nuevo.
+
+Cambio: `--timeout 0` ahora significa "runner inmortal mientras daemon vive". El launcher `start-daemon.sh` setea `--timeout 0` + pre-warm (una llamada `auto tree` inmediata al arrancar el daemon).
+
+Resultado: **pagás ~10-45s cold boot UNA VEZ al arrancar el daemon**. Todas las llamadas siguientes son warm.
+
+---
+
+## Sesión 2026-04-17 — CI + merge
+
+### El CI rompió en macos-15
+
+`Build XCTest runner bundle` job fallaba en GitHub Actions:
+
+```
+xcodebuild: error: Unable to find a destination matching the provided destination specifier
+```
+
+macos-15 runners de GitHub tienen **Xcode 16.4** (no Xcode 26 como mi máquina). El demo xcodeproj fue creado con Xcode 26 y tenía `IPHONEOS_DEPLOYMENT_TARGET = 26.0`. Xcode 16.4 solo tiene SDK iOS 18.x — ningún simulador del runner era compatible.
+
+Fix: bajé `IPHONEOS_DEPLOYMENT_TARGET = 26.0` → `17.0` en los 4 targets del pbxproj. El runner xctest no usa APIs iOS 26-specific; iOS 17 alcanza.
+
+CI verde post-fix:
+```
+✓ Build XCTest runner bundle   2m10s
+✓ build-and-test                41s
+✓ GitGuardian Security Checks    1s
+✓ e2e                          4m38s
+```
+
+### Merge
+
+PR #89 — 8 commits (7 features + 1 CI fix). 4/4 checks. Mergeado.
+
+---
+
+## Hallazgos clave (resumen)
+
+1. **SwiftUI `ToolbarItem` en `NavigationBar` aparecen como `AXGroup` opaco** al AX macOS externo en iOS 26 / Xcode 26. Parece un regression vs iOS 17 (antes sí se exponían). Nadie lo documenta.
+
+2. **Xcode 26 default clona el sim para tests** y destruye el clone al final del ciclo, matando el sim padre. Fix: tres flags `-parallel-testing-enabled NO` + `-disable-concurrent-destination-testing` + `-maximum-concurrent-test-simulator-destinations 1`. Undocumented.
+
+3. **`XCUIApplication` requiere main thread**. Si el servidor corre en background, dispatchar al main con semáforo. El `XCTWaiter.wait()` pumpea el RunLoop — sin eso, deadlock.
+
+4. **`XCUIElement.snapshot()` es la diferencia entre 60s y 2s** para árboles completos. Acceder a propiedades una-por-una es 1 XPC cada una.
+
+5. **Queries tipadas (`app.buttons[x]`) son O(1) vs O(N)** de `descendants(matching: .any).matching(predicate)`.
+
+6. **El daemon como proxy mata latencia**. Saltar el daemon para hot-path baja tap de 1500ms → 430ms (3.5x) con el mismo código de handler.
+
+7. **`--timeout 0` + pre-warm** convierte cold boot de "en cada llamada cuando muera el runner" a "una sola vez por sesión del daemon".
+
+8. **idb sería mejor técnicamente** pero el setup (CLT sincronizadas con Xcode) es demasiado frágil para distribución.
+
+9. **GitHub macos-15 runners tienen Xcode 16.4, no 26**. Los proyectos Xcode 26 no buildan si el deployment target es iOS 26+.
+
+10. **Formato `.xctestrun` v1 vs v2**. Xcode 26 exige v2 con `TestConfigurations`. Generarlo a mano con `PropertyListSerialization` es complicado; más simple apuntar al que Xcode generó en DerivedData.
+
+---
+
+*Para la narrativa pulida y las lecciones consolidadas: [Capítulo 15 — El segundo motor](../libro/15-el-segundo-motor.md).*
+
+*Para el detalle técnico (protocolo, métodos del runner, benchmarks): [docs/ios/XCUI-BRIDGE.md](../ios/XCUI-BRIDGE.md).*


### PR DESCRIPTION
## Summary

Consolida en el libro la investigación y construcción del segundo motor iOS (HybridBridge + XCUIBridge + autopilotd + runner xctest) que se mergeó en #89.

**Solo documentación** — ningún cambio de código.

## Cambios

### 📖 Capítulo 15 — El segundo motor
Narrativa estilo paper técnico siguiendo el molde del [Capítulo 9 — El agente Android](https://github.com/fsaldivar-dev/AutoPilot/blob/main/docs/libro/09-el-agente-android.md), que resuelve un problema análogo. Cubre:

- El problema: `ToolbarItem` SwiftUI invisible en AX macOS externo (con evidencia del árbol aplanado)
- Investigación honesta: cómo lo resuelven Maestro, WebDriverAgent, idb
- Decisión arquitectónica: XCTest runner (no idb) con tabla comparativa
- Implementación: xctest bundle + autopilotd + XCUIBridge cliente
- Tres tropiezos documentados (Xcode 26 clona sim, main thread assertion, tree deep de 60s)
- Arquitectura v2: TCP directo al runner (de 1500ms → 430ms warm)
- `auto list` con queries tipadas + `XCUIElement.snapshot()` (13s → 1s)
- 8 lecciones consolidadas

### 📓 Bitácora XCUI
Diario crudo cronológico de las 6 sesiones desde el spike inicial hasta el merge — decisiones, crashes, hallazgos sin pulir. Patrón paralelo a las bitácoras de `camera/` y `recorder/`.

### 🔗 Cross-links
- Índice del libro: cap 15 agregado + mención en intro + bitácora XCUI en referencias
- Cap 2 (Arquitectura): sección final "Un segundo motor para lo que AX no ve" que puente al 15
- Cap 14 (Validación): footer navega al 15

### 🗺️ ROADMAP
Nueva sección "Segundo motor iOS — siguiente iteración" con P1/P2/P3:
- P1: reemplazar por IdbBridge cuando CLT se destraben (5x más rápido)
- P1: heurística de escalación pre-fallo basada en datos reales
- P2: generador nativo de `.xctestrun` v2 (hoy usamos workaround env var)
- P2: soporte device físico (requiere flow de firma)
- P3: análogo Android si aparece un caso equivalente

## Test plan

- [ ] Leer el cap 15 — narrativa coherente, tono técnico honesto, sin marketing
- [ ] Verificar cross-links (todos existen): `02-arquitectura.md`, `09-el-agente-android.md`, `14-validacion-en-una-app-real.md`, `README.md`, `../ios/XCUI-BRIDGE.md`
- [ ] Bitácora refleja la cronología real de sesiones
- [ ] ROADMAP refleja deudas técnicas reales, no especulativas

🤖 Generated with [Claude Code](https://claude.com/claude-code)