### PR TITLE
fix(recorder): skip AXTextField value as selector fallback (prereq #91)

### DIFF
--- a/cli/Package.swift
+++ b/cli/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         ),
         .testTarget(
             name: "AutoTests",
-            dependencies: ["AutoCore"],
+            dependencies: ["AutoCore", "AutoLibiOS"],
             path: "Tests"
         )
     ]

--- a/cli/Sources/AutoLibiOS/SemanticResolver.swift
+++ b/cli/Sources/AutoLibiOS/SemanticResolver.swift
@@ -114,7 +114,7 @@ public struct SemanticResolver {
 
     // MARK: - Private Helpers
 
-    private struct ElementAttributes {
+    internal struct ElementAttributes {
         let role: String?
         let title: String?
         let label: String?       // AXDescription
@@ -188,28 +188,38 @@ public struct SemanticResolver {
     }
 
     /// Choose the best selector string. Returns (selector, usedIdentifier).
-    private static func chooseBestSelector(_ attrs: ElementAttributes) -> (String?, Bool) {
-        // Priority 1: identifier (if not auto-generated UUID)
+    ///
+    /// Priority: identifier > title > label > value.
+    ///
+    /// The `value` fallback is skipped for text inputs. The value of an
+    /// AXTextField is whatever the user has typed — e.g. during recording
+    /// the email field may hold `"success+714497402@..."`. Emitting that
+    /// as a selector produces a `waitFor "success+..."` in the generated
+    /// script that never matches on replay (the field starts empty). This
+    /// was the P0 bug documented in `recorder_experiment_findings.md`.
+    internal static func chooseBestSelector(_ attrs: ElementAttributes) -> (String?, Bool) {
         if let id = attrs.identifier, isStableIdentifier(id) {
             return (id, true)
         }
 
-        // Priority 2: title
         if let title = attrs.title {
             return (title, false)
         }
 
-        // Priority 3: label (description)
         if let label = attrs.label {
             return (label, false)
         }
 
-        // Priority 4: value (for text fields etc.)
-        if let value = attrs.value, value.count < 50 {
+        if let value = attrs.value, value.count < 50, !isTextInputRole(attrs.role) {
             return (value, false)
         }
 
         return (nil, false)
+    }
+
+    private static func isTextInputRole(_ role: String?) -> Bool {
+        guard let role else { return false }
+        return role == "AXTextField" || role == "AXSecureTextField" || role == "AXTextArea"
     }
 
     /// Check if an identifier looks stable (not auto-generated UUID or random hash).

--- a/cli/Tests/SemanticResolverTests.swift
+++ b/cli/Tests/SemanticResolverTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import AutoLibiOS
+
+final class SemanticResolverTests: XCTestCase {
+
+    // MARK: - P0 bug: value of AXTextField must not leak into selector
+
+    func testTextFieldValueIsNotUsedAsSelector() {
+        // During recording, an email field has been typed into. The tree
+        // shows its `value` as "success+714497402@example.com". Before the
+        // fix, chooseBestSelector emitted that whole string, producing an
+        // unreproducible `waitFor "success+..."` in the script.
+        let attrs = SemanticResolver.ElementAttributes(
+            role: "AXTextField",
+            title: nil,
+            label: nil,
+            identifier: nil,
+            value: "success+714497402@example.com"
+        )
+        let (selector, _) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertNil(selector, "value of AXTextField must not be used as selector")
+    }
+
+    func testSecureTextFieldValueIsNotUsedAsSelector() {
+        let attrs = SemanticResolver.ElementAttributes(
+            role: "AXSecureTextField",
+            title: nil,
+            label: nil,
+            identifier: nil,
+            value: "Passw0rd!"
+        )
+        let (selector, _) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertNil(selector)
+    }
+
+    func testTextAreaValueIsNotUsedAsSelector() {
+        let attrs = SemanticResolver.ElementAttributes(
+            role: "AXTextArea",
+            title: nil,
+            label: nil,
+            identifier: nil,
+            value: "Multi-line user content"
+        )
+        let (selector, _) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertNil(selector)
+    }
+
+    // MARK: - Normal priorities still work
+
+    func testIdentifierWinsOverEverything() {
+        let attrs = SemanticResolver.ElementAttributes(
+            role: "AXButton",
+            title: "Login",
+            label: "Log in button",
+            identifier: "login_button",
+            value: nil
+        )
+        let (selector, usedId) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertEqual(selector, "login_button")
+        XCTAssertTrue(usedId)
+    }
+
+    func testTitleWinsWhenNoIdentifier() {
+        let attrs = SemanticResolver.ElementAttributes(
+            role: "AXButton",
+            title: "Continue",
+            label: "Continue button",
+            identifier: nil,
+            value: nil
+        )
+        let (selector, usedId) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertEqual(selector, "Continue")
+        XCTAssertFalse(usedId)
+    }
+
+    func testLabelWinsWhenNoTitle() {
+        let attrs = SemanticResolver.ElementAttributes(
+            role: "AXImage",
+            title: nil,
+            label: "User avatar",
+            identifier: nil,
+            value: nil
+        )
+        let (selector, _) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertEqual(selector, "User avatar")
+    }
+
+    // MARK: - value is still usable for non-input roles
+
+    func testValueIsUsedForSwitch() {
+        // A switch's value ("1" or "0") is not user-typed content, so it's
+        // safe to fall back to. Typically the label comes first anyway;
+        // this only hits in oddly accessible switches.
+        let attrs = SemanticResolver.ElementAttributes(
+            role: "AXCheckBox",
+            title: nil,
+            label: nil,
+            identifier: nil,
+            value: "Enabled"
+        )
+        let (selector, _) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertEqual(selector, "Enabled")
+    }
+
+    func testValueLongerThan50IsRejected() {
+        let attrs = SemanticResolver.ElementAttributes(
+            role: "AXStaticText",
+            title: nil,
+            label: nil,
+            identifier: nil,
+            value: String(repeating: "x", count: 60)
+        )
+        let (selector, _) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertNil(selector)
+    }
+
+    // MARK: - No attributes at all
+
+    func testAllNilReturnsNil() {
+        let attrs = SemanticResolver.ElementAttributes(
+            role: nil, title: nil, label: nil, identifier: nil, value: nil
+        )
+        let (selector, usedId) = SemanticResolver.chooseBestSelector(attrs)
+        XCTAssertNil(selector)
+        XCTAssertFalse(usedId)
+    }
+}

--- a/docs/recorder/HALLAZGOS.md
+++ b/docs/recorder/HALLAZGOS.md
@@ -49,6 +49,16 @@ Para comparar contra Maestro Studio y Appium Inspector en el benchmark.
 
 **Fix propuesto**: Detectar scroll indirectamente comparando las posiciones de los children del AXGroup contenedor entre frames (si los children se movieron, hubo scroll). Requiere un background thread que monitoree posiciones.
 
+### 2b. `waitFor "<value>"` por contenido de text fields — RESUELTO (2026-04-17, prereq #91)
+
+**Problema**: durante grabacion el recorder emitia `waitFor` con el contenido de un `AXTextField` cuando era el unico selector disponible (sin id, sin title, sin label). Ejemplo: un field de email con value `success+714497402@example.com` terminaba en el script como `waitFor "success+714497402@..."`. En el replay desde estado limpio el field arranca vacio → el `waitFor` agota el timeout y el script falla en la mitad.
+
+**Fix**: en `SemanticResolver.chooseBestSelector` (`cli/Sources/AutoLibiOS/SemanticResolver.swift:200-226`), la priority 4 (value fallback) ahora se saltea cuando el rol del elemento es `AXTextField`, `AXSecureTextField` o `AXTextArea`. Esos valores son contenido del usuario, no texto estable de la UI. El elemento cae a selector `nil` → el recorder emite `tapAt` con coordenadas en vez de inventar un selector que no sobrevive el replay.
+
+**Tests**: `cli/Tests/SemanticResolverTests.swift` con 9 casos — los tres roles de input + casos donde value SI se mantiene (switch con "Enabled", etc) + prioridades normales intactas.
+
+**Referencia**: memoria `recorder_experiment_findings.md` documenta el bug como P0 critica desde 2026-04-07.
+
 ### 2. scrollTo no verifica visibilidad — RESUELTO (2026-04-17, issues #49 #58 #61)
 
 **Problema original**: `scrollTo "X"` buscaba el elemento con `search()` que recorre todo el AX tree. En iOS y Android, el AX tree incluye elementos offscreen (fuera del viewport). Entonces `scrollTo` retornaba "encontrado" inmediatamente sin scrollear porque el elemento existe en el tree aunque no sea visible.


### PR DESCRIPTION
## Summary

Arregla el **bug P0 del recorder** documentado desde 2026-04-07 en `memory/recorder_experiment_findings.md`: el recorder emitía `waitFor "<value>"` por contenidos de text fields, haciendo que el script grabado fuera imposible de reproducir desde estado limpio.

**Ejemplo real del bug**: field de email con value `success+714497402@example.com` → script con `waitFor \"success+714497402@...\"` → replay falla en ~50% del script.

## Fix

Seis líneas en `SemanticResolver.chooseBestSelector`: la priority 4 (value fallback) ahora se saltea cuando el rol es `AXTextField`, `AXSecureTextField` o `AXTextArea`. Esos valores son contenido del usuario, no texto estable de la UI.

El elemento cae a selector `nil` → el recorder emite `tapAt x y` con coordenadas. Menos portable que un selector semántico, pero al menos reproducible.

## Tests

`cli/Tests/SemanticResolverTests.swift` con **9 tests**:
- Bug P0 directo: los tres roles de input (TextField, SecureTextField, TextArea) con value largo → selector nil
- Priorities normales intactas: identifier wins, title wins, label wins  
- Cases donde value SI se usa: checkbox con \"Enabled\"
- Edge cases: todo nil, value >50 chars

Package.swift: AutoTests ahora depende de AutoLibiOS también. `ElementAttributes` y `chooseBestSelector` promoted de `private` → `internal` para ser testeables.

## Scope

Es el **prerequisito explícito del issue #91** (\"Paso 1 es no-opcional\" — del propio body del issue). Este PR NO cierra #91 porque el issue es umbrella que engloba 5 pasos; solo cierra su pre-req. Los pasos 2-4 (hit-test classification, snapshot diff, semantic heuristics) siguen abiertos y se benefician de tener esta base limpia.

## Por qué PR chico

1. Valor inmediato: desbloquea replay de scripts grabados con text fields (login, forms, chat — el caso común del recorder).
2. Cambio aditivo, cero riesgo de regresión: el fix solo añade una guard clause.
3. El scope ambicioso (online→offline rewrite del recorder) no es validable en esta sesión (runner XCUI + AX tree del Simulator inestables hoy — ver bitácora #80). Shipping incrementalmente es el patrón que funcionó hoy con #92 y #93.

## Test plan

- [x] \`swift build\` — verde
- [x] \`swift test\` — 97/97 pass (88 existentes + 9 nuevos)
- [x] El test \`testTextFieldValueIsNotUsedAsSelector\` reproduce el bug exacto del issue y pasa
- [ ] Validación empírica con \`auto record\` contra app real con text fields (login flow) — pendiente para #91 siguientes pasos

## Archivos

| | |
|---|---|
| `cli/Sources/AutoLibiOS/SemanticResolver.swift` | +15/-7 (fix + doc comment + isTextInputRole helper) |
| `cli/Tests/SemanticResolverTests.swift` | +123 (9 tests, nuevo) |
| `cli/Package.swift` | +1/-1 (AutoTests deps) |
| `docs/recorder/HALLAZGOS.md` | +10 (sección 2b con el fix) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)