### PR TITLE
fix: waitFor 3.9× más rápido + editor binary refresh

### DIFF
--- a/cli/Sources/AutoCore/CommandDispatcher.swift
+++ b/cli/Sources/AutoCore/CommandDispatcher.swift
@@ -309,21 +309,35 @@ public func executeSharedCommand(_ args: [String], bridge: any DeviceBridge, dee
         }
         let target = args[1]
         let timeout = args.count >= 3 ? Double(args[2]) ?? 10.0 : 10.0
-        let pollInterval: useconds_t = 500_000
-        let maxAttempts = Int(timeout * 2)
+
+        // #79: poll interval bajado de 500ms → 100ms para capturar transiciones
+        // breves (dialogs de permisos <500ms). Para mantener el CPU cost acotado
+        // usamos `existsFast` (shallow, ~5-10ms) cuando el requiredCount es 1;
+        // solo caemos a `search()` full-tree si el caller pide `label[N]` con N>1.
+        let pollInterval: useconds_t = 100_000
+        let maxAttempts = Int(timeout * 10)
 
         // Support label[N] syntax: waitFor "Cerrar sesion[2]" waits for 2+ matches
         let (searchLabel, requiredCount) = TargetResolverShared.parse(target)
         let minMatches = requiredCount ?? 1
+        let needsCountQuery = minMatches > 1
 
         var found = false
         var pollCount = 0
         for _ in 0..<maxAttempts {
             pollCount += 1
-            // Catch errors (e.g., "No active window" during app launch) and retry
-            if let results = try? bridge.search(query: searchLabel), results.count >= minMatches {
-                found = true
-                break
+            if needsCountQuery {
+                // label[N] — necesitamos contar, cae a search() full-tree
+                if let results = try? bridge.search(query: searchLabel), results.count >= minMatches {
+                    found = true
+                    break
+                }
+            } else {
+                // Caso común: solo nos importa ≥1 match. existsFast binario.
+                if (try? bridge.existsFast(label: searchLabel)) == true {
+                    found = true
+                    break
+                }
             }
             usleep(pollInterval)
         }
@@ -343,19 +357,29 @@ public func executeSharedCommand(_ args: [String], bridge: any DeviceBridge, dee
         }
         let target = args[1]
         let timeout = args.count >= 3 ? Double(args[2]) ?? 10.0 : 10.0
-        let pollInterval: useconds_t = 500_000
-        let maxAttempts = Int(timeout * 2)
+
+        // #79: mismo tratamiento que waitFor — poll 100ms + existsFast
+        let pollInterval: useconds_t = 100_000
+        let maxAttempts = Int(timeout * 10)
 
         // Support label[N] syntax: waitUntilGone "Item[2]" waits until fewer than 2 matches
         let (searchLabel, requiredCount) = TargetResolverShared.parse(target)
         let minMatches = requiredCount ?? 1
+        let needsCountQuery = minMatches > 1
 
         var gone = false
         for _ in 0..<maxAttempts {
-            let results = (try? bridge.search(query: searchLabel)) ?? []
-            if results.count < minMatches {
-                gone = true
-                break
+            if needsCountQuery {
+                let results = (try? bridge.search(query: searchLabel)) ?? []
+                if results.count < minMatches {
+                    gone = true
+                    break
+                }
+            } else {
+                if (try? bridge.existsFast(label: searchLabel)) == false {
+                    gone = true
+                    break
+                }
             }
             usleep(pollInterval)
         }

--- a/cli/Sources/AutoCore/DeviceBridge.swift
+++ b/cli/Sources/AutoCore/DeviceBridge.swift
@@ -11,6 +11,14 @@ public protocol DeviceBridge {
     func search(query: String) throws -> [[String: Any]]
     func elementAt(x: Double, y: Double) throws -> [String: Any]?
 
+    /// Verificación binaria rápida de existencia por label/title/identifier.
+    /// Diseñado para loops tight (`waitFor`/`waitUntilGone`) donde importa más
+    /// latencia que completitud — devuelve al primer match, sin serializar.
+    ///
+    /// **Default**: cae a `search(query:)`. Bridges que pueden hacerlo más
+    /// barato deben override con una implementación shallow (no-recursiva).
+    func existsFast(label: String) throws -> Bool
+
     // MARK: - Actions
 
     func tap(target: String) throws
@@ -149,6 +157,14 @@ public protocol DeviceBridge {
 /// real work — everything else degrades to a documented no-op so the
 /// same `.auto` script runs on iOS and Android without branching.
 public extension DeviceBridge {
+    /// Default `existsFast`: cae a `search(query:)`. Más caro que un query
+    /// shallow pero correcto — bridges que tengan un atajo (SimulatorBridge
+    /// iOS con AX directo, AgentBridge Android con tree cached) deben override.
+    func existsFast(label: String) throws -> Bool {
+        let results = try search(query: label)
+        return !results.isEmpty
+    }
+
     /// Default: no-op with a printed note. The post-condition "fresh
     /// credential state for next launch" is already satisfied on Android
     /// by the per-app Keystore model (uninstall releases the UID and

--- a/cli/Sources/AutoLibiOS/SimulatorBridge.swift
+++ b/cli/Sources/AutoLibiOS/SimulatorBridge.swift
@@ -1124,6 +1124,23 @@ public final class SimulatorBridge {
         }
     }
 
+    // MARK: - existsFast (#79)
+
+    /// Shallow existence check por label/title/identifier.
+    /// Early-exit en primer match, sin serializar atributos extra.
+    ///
+    /// Benchmark en iPhone 17 iOS 26.3:
+    ///   * `search()` (full tree serialize): ~30-50ms
+    ///   * `existsFast()` (shallow find):      ~5-10ms
+    ///
+    /// Uso principal: loops de `waitFor`/`waitUntilGone` donde queremos
+    /// polls frecuentes sin saturar CPU. El maxDepth=12 cubre los casos
+    /// típicos de UI iOS (~5-8 niveles) con margen.
+    public func existsFast(label: String) throws -> Bool {
+        let root = try findSimulatorContent()
+        return findAXElement(in: root, matching: label, depth: 0, maxDepth: 12) != nil
+    }
+
     /// Finds the raw AXUIElement matching target (for performing actions).
     /// Priority: exact match (all depths) → contains match (all depths)
     private func findAXElement(in element: AXUIElement, matching target: String, depth: Int, maxDepth: Int) -> AXUIElement? {

--- a/cli/Tests/WaitForTests.swift
+++ b/cli/Tests/WaitForTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+import CoreGraphics
+@testable import AutoCore
+
+/// Bridge mock programable para tests de `waitFor`/`waitUntilGone`.
+/// Permite setear una secuencia de respuestas para `existsFast` y contar
+/// cuántas veces fue consultado.
+final class WaitForMockBridge: DeviceBridge {
+    var existsSequence: [Bool] = []
+    var existsFastCallCount = 0
+    var searchCallCount = 0
+
+    // Para casos `label[N]` con N>1 — waitFor cae a search()
+    var searchResultsSequence: [[[String: Any]]] = []
+
+    // MARK: - Overrides relevantes
+
+    func existsFast(label: String) throws -> Bool {
+        existsFastCallCount += 1
+        if existsSequence.isEmpty { return false }
+        return existsSequence.removeFirst()
+    }
+
+    func search(query: String) throws -> [[String: Any]] {
+        searchCallCount += 1
+        if searchResultsSequence.isEmpty { return [] }
+        return searchResultsSequence.removeFirst()
+    }
+
+    // MARK: - Protocolo no relevante (stubs)
+
+    func tree() throws -> [[String: Any]] { [] }
+    func elementAt(x: Double, y: Double) throws -> [String: Any]? { nil }
+    func tap(target: String) throws {}
+    func longPress(target: String, duration: Double) throws {}
+    func doubleTap(target: String) throws {}
+    func clear(target: String) throws {}
+    func typeText(_ text: String) throws {}
+    func scroll(target: String, direction: String) throws {}
+    func swipe(direction: String) throws {}
+    func tapAtCoordinate(x: Double, y: Double) throws {}
+    func launchApp(bundleId: String, envVars: [String: String]) throws {}
+    func terminateApp(bundleId: String) throws {}
+    func listDevices() throws -> [[String: Any]] { [] }
+    func bootDevice(_ nameOrUdid: String) throws {}
+    func shutdownDevice(_ nameOrUdid: String) throws {}
+    func installApp(path: String) throws {}
+    func getBootedDeviceId() throws -> String { "mock" }
+    func screenshot(path: String) throws {}
+    func addMedia(path: String) throws {}
+    func openURL(_ url: String) throws {}
+    func setPasteboard(text: String) throws {}
+    func getPasteboard() throws -> String { "" }
+    func biometricEnroll() throws {}
+    func biometricUnenroll() throws {}
+    func biometricMatch() throws {}
+    func biometricFail() throws {}
+    func biometricIsEnrolled() throws -> Bool { false }
+    func getLogs(bundleId: String?, lines: Int) throws -> String { "" }
+    func setPermission(action: String, service: String, bundleId: String) throws {}
+    func rotate(direction: String) throws {}
+    func drag(from: String, to: String, duration: Double) throws {}
+    func dragCoordinates(x1: Double, y1: Double, x2: Double, y2: Double, duration: Double) throws {}
+    func pressKey(key: String) throws {}
+    func hideKeyboard() throws {}
+    func eraseText(count: Int) throws {}
+    func copyTextFrom(target: String) throws -> String { "" }
+    func clearState(bundleId: String) throws {}
+    func uninstallApp(bundleId: String) throws {}
+    func viewport() throws -> CGRect { .zero }
+    func scrollTo(target: String, direction: String, maxAttempts: Int) throws {}
+    func startRecording() throws {}
+    func stopRecording(outputPath: String) throws {}
+    func setLocation(latitude: Double, longitude: Double) throws {}
+    func setAppearance(mode: String) throws {}
+    func lockDevice() throws {}
+    func unlockDevice() throws {}
+    func pushFile(localPath: String, remotePath: String) throws {}
+    func pullFile(remotePath: String, localPath: String) throws {}
+}
+
+// MARK: - Tests
+
+final class WaitForTests: XCTestCase {
+
+    var bridge: WaitForMockBridge!
+
+    override func setUp() {
+        bridge = WaitForMockBridge()
+    }
+
+    // MARK: - waitFor happy path
+
+    func testWaitFor_returnsWhenElementAppears() throws {
+        // Primera consulta: no existe. Segunda: aparece.
+        bridge.existsSequence = [false, true]
+
+        try executeSharedCommand(["waitFor", "Login", "1"], bridge: bridge)
+
+        // existsFast debe haberse llamado al menos 2 veces
+        XCTAssertGreaterThanOrEqual(bridge.existsFastCallCount, 2)
+        XCTAssertEqual(bridge.searchCallCount, 0, "No debe caer a search() para label simple")
+    }
+
+    func testWaitFor_timesOutWhenElementNeverAppears() throws {
+        // existSequence vacío → siempre false → timeout
+        bridge.existsSequence = []
+
+        XCTAssertThrowsError(
+            try executeSharedCommand(["waitFor", "Ghost", "0.3"], bridge: bridge)
+        ) { error in
+            if let bridgeErr = error as? BridgeError,
+               case .timeout(let msg) = bridgeErr {
+                XCTAssertTrue(msg.contains("Ghost"))
+            } else {
+                XCTFail("Se esperaba BridgeError.timeout, obtuve: \(error)")
+            }
+        }
+
+        // Con timeout 0.3s y poll 100ms: al menos 3 intentos, posiblemente más
+        XCTAssertGreaterThanOrEqual(bridge.existsFastCallCount, 3)
+    }
+
+    // MARK: - waitUntilGone symmetric
+
+    func testWaitUntilGone_returnsWhenElementDisappears() throws {
+        // Presente → presente → desaparece
+        bridge.existsSequence = [true, true, false]
+
+        try executeSharedCommand(["waitUntilGone", "Dialog", "1"], bridge: bridge)
+
+        XCTAssertGreaterThanOrEqual(bridge.existsFastCallCount, 3)
+    }
+
+    func testWaitUntilGone_timesOutWhenElementStays() throws {
+        // Secuencia infinita de true → nunca se va → timeout
+        // (con poll 100ms y timeout 0.3s, consumiremos ~3-4)
+        bridge.existsSequence = Array(repeating: true, count: 20)
+
+        XCTAssertThrowsError(
+            try executeSharedCommand(["waitUntilGone", "Ad", "0.3"], bridge: bridge)
+        )
+    }
+
+    // MARK: - label[N] syntax → fallback a search()
+
+    func testWaitFor_withOccurrenceFallsBackToSearch() throws {
+        // `label[2]` requiere contar → search, no existsFast
+        let match: [String: Any] = ["label": "Item"]
+        bridge.searchResultsSequence = [[match, match]]  // 2 matches de una
+
+        try executeSharedCommand(["waitFor", "Item[2]", "1"], bridge: bridge)
+
+        XCTAssertEqual(bridge.existsFastCallCount, 0, "Con label[N] N>1 NO debe llamar existsFast")
+        XCTAssertGreaterThanOrEqual(bridge.searchCallCount, 1)
+    }
+
+    // MARK: - Poll interval aceleración (#79)
+
+    /// Con pollInterval=100ms y timeout=1s, el loop debe intentar ~10 veces
+    /// (era 2 con pollInterval=500ms). Esto confirma la aceleración del #79.
+    func testWaitFor_pollsMoreFrequentlyThanLegacy() throws {
+        bridge.existsSequence = []  // nunca encontrado
+
+        _ = try? executeSharedCommand(["waitFor", "X", "1"], bridge: bridge)
+
+        // Pre-fix: ~2 polls (500ms interval). Post-fix: ~10 polls (100ms interval).
+        XCTAssertGreaterThanOrEqual(bridge.existsFastCallCount, 5,
+            "Con pollInterval 100ms y timeout 1s deberíamos tener ≥5 polls")
+    }
+}

--- a/editor/src-tauri/tauri.conf.json
+++ b/editor/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "dev.autopilot.editor",
   "build": {
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "./refresh-binaries.sh && npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "npm run build",
+    "beforeBuildCommand": "./refresh-binaries.sh --release && npm run build",
     "frontendDist": "../dist"
   },
   "app": {


### PR DESCRIPTION
## Summary

Dos fixes chicos del daily dev loop — sin tocar arquitectura ARD-001.

- **Closes #79** — `waitFor`/`waitUntilGone` 3.9× más rápido
- **Closes #81** — Editor refresca binarios sidecar automáticamente

## #79 waitFor hybrid fast

| Antes | Después |
|-------|---------|
| Poll 500ms × `search()` full-tree (~30ms) | Poll 100ms × `existsFast()` shallow (~5-10ms) |
| Flakiness en transiciones <500ms | Captura dialogs de ~200ms |
| `waitFor "Explorea"` → **596ms** | → **153ms** (3.9× más rápido) |

- Nuevo `DeviceBridge.existsFast(label:)` con default que cae a `search()`. Bridges con atajo shallow (SimulatorBridge iOS) override.
- `waitFor`/`waitUntilGone` usan `existsFast` para target simple. `label[N]` con N>1 sigue usando `search()` porque necesita contar.

## #81 editor binary refresh

`editor/src-tauri/tauri.conf.json` ahora invoca `./refresh-binaries.sh` antes de `npm run dev|build`. Cada `tauri dev/build` garantiza binarios sidecar frescos desde `cli/.build/`.

Si el CLI no está compilado, `refresh-binaries.sh` sale con exit 1 y el dev ve el error claro.

## Tests

- `cli/Tests/WaitForTests.swift` — 6 tests con `WaitForMockBridge`
- `swift test` — **121/121 verdes** (+6 nuevos)
- `swift build` — 0 warnings

## Test plan

- [x] `swift build && swift test` — 121/121 verdes
- [x] `auto run scripts/examples/smoke-ard001.auto` — 7/7, waitFor 153ms
- [x] `auto-android run scripts/examples/smoke-ard001.auto` — 7/7, 952ms
- [ ] Verificación manual: `cd editor/src-tauri && cargo clean && cd .. && npm run tauri dev` arranca con binarios frescos (reportar en review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)