### PR TITLE
fix(android): handleSwipe acepta coordenadas — repara scroll y drag (#127)

### DIFF
--- a/agent/app/src/main/kotlin/dev/autopilot/agent/SocketServer.kt
+++ b/agent/app/src/main/kotlin/dev/autopilot/agent/SocketServer.kt
@@ -201,7 +201,37 @@ class SocketServer(
     // ── Swipe ────────────────────────────────────────────
 
     private fun handleSwipe(params: JSONObject?): String {
-        val direction = params?.optString("direction", "") ?: return errorResponse("Missing direction")
+        // Dos formas del mensaje, mutuamente excluyentes:
+        //   {direction}              — swipe direccional de pantalla completa
+        //   {x1,y1,x2,y2[,duration]} — swipe entre coordenadas; la usan
+        //                              `scroll <elem> <dir>` y `drag` (AgentBridge)
+        if (params == null) return errorResponse("Missing params: direction or x1,y1,x2,y2")
+
+        val hasDirection = params.optString("direction", "").isNotEmpty()
+        val coordKeys = listOf("x1", "y1", "x2", "y2")
+        val presentCoords = coordKeys.filter { params.has(it) }
+
+        if (hasDirection && presentCoords.isNotEmpty()) {
+            return errorResponse("Ambiguous swipe: send either direction or x1,y1,x2,y2, not both")
+        }
+
+        if (presentCoords.isNotEmpty()) {
+            if (presentCoords.size < coordKeys.size) {
+                return errorResponse("Swipe coordinates require all of x1,y1,x2,y2 (got: $presentCoords)")
+            }
+            // Clamp a >= 0: elementos parcialmente fuera de pantalla producen
+            // bounds negativos en boundsInScreen — clampear, no rechazar
+            val x1 = params.optInt("x1").coerceAtLeast(0)
+            val y1 = params.optInt("y1").coerceAtLeast(0)
+            val x2 = params.optInt("x2").coerceAtLeast(0)
+            val y2 = params.optInt("y2").coerceAtLeast(0)
+            val duration = params.optLong("duration", 300L).coerceIn(1L, 60_000L)
+            input.swipe(x1, y1, x2, y2, duration)
+            return successResponse("from" to "$x1,$y1", "to" to "$x2,$y2")
+        }
+
+        val direction = params.optString("direction", "")
+        if (direction.isEmpty()) return errorResponse("Missing direction or coordinates")
 
         // Get screen size from root window bounds
         val root = getRoot() ?: return errorResponse("No active window")


### PR DESCRIPTION
## Summary
`scroll <elem> <dir>` y `drag` fallaban 100% con `Invalid direction: .` — el CLI (AgentBridge) siempre envió el mensaje `swipe` con coordenadas `x1,y1,x2,y2`, pero `handleSwipe` del agente solo leía `direction`. El agente ahora acepta las dos formas del mensaje, mutuamente excluyentes, con contrato explícito:
- ambas presentes → error explícito (no ignora una en silencio)
- coords incompletas → error claro (antes: el engañoso `Missing direction`)
- coords negativas (elementos semi-fuera de pantalla) → clamp a 0
- `duration` acotada a [1ms, 60s]

## Test plan
- [x] `auto-android scroll "Atardecer en Santorini" down` → `Scrolled (692ms)` (demo TestAutomatitacion, API 35)
- [x] `auto-android drag "Todos" "Cultura"` → `Dragged (710ms)`
- [x] `auto-android swipe up` → sin regresión en la forma direccional (669ms)
- [x] APK recompilado e instalado en emulador; agente re-verificado con setup + ping

## Archivos
| Archivo | Cambio |
|---|---|
| `agent/.../SocketServer.kt` | handleSwipe: dispatch explícito direction/coords + clamps |

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)