### PR TITLE
fix(android): copyTextFrom lee title/value/label del árbol (#128)

### DIFF
--- a/cli/Sources/AutoCore/AgentBridge.swift
+++ b/cli/Sources/AutoCore/AgentBridge.swift
@@ -682,7 +682,14 @@ public final class AgentBridge: DeviceBridge {
         guard let element = findElement(in: currentTree, matching: target) else {
             throw BridgeError.elementNotFound(target)
         }
-        return element["text"] as? String ?? element["label"] as? String ?? ""
+        // El árbol del agente expone node.text como "title"/"value" y
+        // contentDescription como "label" (ver TreeSerializer.kt) — no existe key "text"
+        for key in ["title", "value", "label"] {
+            if let text = element[key] as? String, !text.isEmpty {
+                return text
+            }
+        }
+        return ""
     }
 
     // MARK: - DeviceBridge: App Lifecycle (via adb)


### PR DESCRIPTION
## Summary
`copyTextFrom` devolvía cadena vacía siempre: leía `element["text"]` (key que no existe en el árbol del agente) con fallback a `label` (contentDescription, casi siempre vacío en TextViews). El agente serializa `node.text` como `title`/`value` (TreeSerializer.kt:41,50). Ahora prueba `title` → `value` → `label` y devuelve el primer no-vacío.

## Test plan
- [x] `auto-android copyTextFrom "Atardecer en Santorini"` → devuelve el texto (antes: vacío)
- [x] `auto-android copyTextFrom "Gastronomia"` → `Gastronomia`
- [x] Verificado que los callers (CommandDispatcher, LegacyBridgeAdapter) no dependían del vacío

## Archivos
| Archivo | Cambio |
|---|---|
| `cli/Sources/AutoCore/AgentBridge.swift` | copyTextFrom: keys correctas del árbol JSON |

Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)