### PR TITLE
fix(android): setup encuentra el APK del agente en clone fresco (#129)

### DIFF
--- a/cli/Sources/AutoCore/AndroidSetup.swift
+++ b/cli/Sources/AutoCore/AndroidSetup.swift
@@ -130,7 +130,8 @@ public enum AndroidSetup {
         let apkPath = findAgentApk()
         guard let apk = apkPath else {
             print("⚠ Agent APK not found in repo — skipping install")
-            print("  Build with: cd agent/android && ./gradlew :agent:assembleDebug")
+            print("  Build with: cd agent && ./gradlew :app:assembleDebug")
+            print("  (requiere ANDROID_HOME o agent/local.properties con sdk.dir)")
             return
         }
 
@@ -150,12 +151,9 @@ public enum AndroidSetup {
     }
 
     private static func findAgentApk() -> String? {
-        let repoRoot = findRepoRoot()
-        let candidates = [
-            "\(repoRoot)/agent/android/agent/build/outputs/apk/debug/agent-debug.apk",
-            "\(repoRoot)/Demo/Android/AgentApp/app/build/outputs/apk/debug/app-debug.apk"
-        ]
-        return candidates.first(where: { FileManager.default.fileExists(atPath: $0) })
+        // Proyecto gradle en agent/, módulo :app — ver agent/settings.gradle.kts
+        let apk = "\(findRepoRoot())/agent/app/build/outputs/apk/debug/app-debug.apk"
+        return FileManager.default.fileExists(atPath: apk) ? apk : nil
     }
 
     private static func findRepoRoot() -> String {


### PR DESCRIPTION
## Summary
`auto-android setup` en un clone fresco nunca encontraba el APK del agente: `findAgentApk()` buscaba en dos layouts que ya no existen (`agent/android/...`, `Demo/Android/AgentApp/...` — código muerto, eliminado) y el mensaje de ayuda apuntaba a un directorio y módulo gradle inexistentes. Ahora busca en la ruta real (`agent/app/build/outputs/apk/debug/app-debug.apk`) y el mensaje indica el comando correcto + el requisito de ANDROID_HOME/local.properties.

## Test plan
- [x] `adb uninstall dev.autopilot.agent` + `auto-android setup` → encuentra el APK, lo instala, agente listo en 1s (E2E completo verificado)
- [x] `auto-android ping` post-reinstall → 64ms

## Archivos
| Archivo | Cambio |
|---|---|
| `cli/Sources/AutoCore/AndroidSetup.swift` | findAgentApk ruta real + mensaje de build correcto |

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)